### PR TITLE
Add SSP RK schemes

### DIFF
--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -806,7 +806,7 @@ class LSRK4MethodBuilder(MethodBuilder):
 class SSPRKMethodBuilder(MethodBuilder):
     r"""Explicit Strong Stability Preserving (SSP) Runge-Kutta Methods.
 
-    The methods are given in the now-standard Shu-Oscher form
+    The methods are given in the now-standard Shu-Osher form
 
         .. math::
 

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -795,4 +795,50 @@ class LSRK4MethodBuilder(MethodBuilder):
 # }}}
 
 
+# {{{ Explicit SSP Runge-Kutta methods
+
+class SSPRKMethodBuilder(MethodBuilder):
+    r"""Explicit Strong Stability Preserving (SSP) Runge-Kutta Methods.
+
+    The methods are given in the now-standard Shu-Oscher form
+
+        .. math::
+
+            \begin{aligned}
+            y^{(i)} =\,\, & \sum_{k = 0}^{i - 1}
+                \alpha_{ik} y^{(i)} + \Delta t \beta_{ik} f(y^{(i)}), \\
+            y^{n + 1} = y^{(n)},
+            \end{aligned}
+
+    for :math:`i \in \{1, \dots, n\}` and :math:`y^{(0)} = y^n`. For reference,
+    see [gst-2001]_.
+
+    .. [gst-2001] S. Gottlieb, C.-W. Shu, E. Tadmor, *Strong Stability
+        Preserving High-Order Time Discretization Methods*, SIAM, Vol. 43,
+        pp. 89-112, 2001.
+    """
+
+    def __init__(self, component_id, state_filter_name=None, rhs_func_name=None):
+        super().__init__()
+
+        state_filter = state_filter_name
+        if state_filter is not None:
+            state_filter = var(f"<func>{state_filter_name}")
+
+        if rhs_func_name is None:
+            rhs_func_name = f"<func>{component_id}"
+
+        self.component_id = component_id
+        self.dt = var("<dt>")
+        self.t = var("<t>")
+        self.state = var(f"<state>{component_id}")
+        self.state_filter = state_filter
+
+    def generate(self):
+        """
+        :returns: a :class:`~dagrt.language.DAGCode`.
+        """
+
+# }}}
+
 # vim: foldmethod=marker

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -808,13 +808,13 @@ class SSPRKMethodBuilder(MethodBuilder):
 
     The methods are given in the now-standard Shu-Osher form
 
-        .. math::
+    .. math::
 
-            \begin{aligned}
-            y^{(i)} =\,\, & \sum_{k = 0}^{i - 1}
-                \alpha_{ik} y^{(i)} + \Delta t \beta_{ik} f(y^{(i)}), \\
-            y^{n + 1} =\,\, & y^{(n)},
-            \end{aligned}
+        \begin{aligned}
+        y^{(i)} =\,\, & \sum_{k = 0}^{i - 1}
+            \alpha_{ik} y^{(i)} + \Delta t \beta_{ik} f(y^{(i)}), \\
+        y^{n + 1} =\,\, & y^{(n)},
+        \end{aligned}
 
     for :math:`i \in \{1, \dots, n\}` and :math:`y^{(0)} = y^n`. For reference,
     see [gst-2001]_.

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -826,7 +826,7 @@ class SSPRKMethodBuilder(MethodBuilder):
             state_filter = var(f"<func>{state_filter_name}")
 
         if rhs_func_name is None:
-            rhs_func_name = "component_id"
+            rhs_func_name = component_id
 
         self.component_id = component_id
         self.dt = var("<dt>")
@@ -856,7 +856,7 @@ class SSPRKMethodBuilder(MethodBuilder):
 
         nstages = len(self.alpha)
         for n in range(1, nstages + 1):
-            if len(self.alpha) > n or len(self.beta) > n:
+            if len(self.alpha[n - 1]) > n or len(self.beta[n - 1]) > n:
                 raise ValueError("only explicit SSP schemes are supported")
 
         # }}}

--- a/test/test_rk.py
+++ b/test/test_rk.py
@@ -33,7 +33,9 @@ from leap.rk import (
         ForwardEulerMethodBuilder,
         MidpointMethodBuilder, HeunsMethodBuilder,
         RK3MethodBuilder, RK4MethodBuilder, RK5MethodBuilder,
-        LSRK4MethodBuilder,)
+        LSRK4MethodBuilder,
+        SSPRK22MethodBuilder, SSPRK33MethodBuilder,
+        )
 from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
 import numpy as np
 
@@ -65,6 +67,8 @@ logger = logging.getLogger(__name__)
     (LSRK4MethodBuilder("y"), 4),
     (KennedyCarpenterIMEXARK4MethodBuilder("y", use_implicit=False,
         explicit_rhs_name="y"), 4),
+    (SSPRK22MethodBuilder("y"), 2),
+    (SSPRK33MethodBuilder("y"), 3),
     ])
 def test_rk_accuracy(python_method_impl, method, expected_order,
                      show_dag=False, plot_solution=False):


### PR DESCRIPTION
This just adds the classic 2nd and 3rd order SSP schemes.

Some conceptual "issues"
* It's not generalized at all and just supports explicit SSP schemes.
* Most (if not all?) SSP schemes can actually be written out as a Butcher tableau. Not quite sure if there's a benefit to writing them in the Osher-Shu form like this.