### PR TITLE
Fully Explicit Embedded Adams w/Adaptive Timestep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
         -   name: "Main Script"
             run: |
-                EXTRA_INSTALL="numpy"
+                EXTRA_INSTALL="numpy scipy"
                 sudo apt update
                 sudo apt install gfortran-7 liblapack-dev libblas-dev
                 sudo ln -sf /usr/bin/gfortran-7 /usr/bin/gfortran

--- a/leap/implicit.py
+++ b/leap/implicit.py
@@ -86,3 +86,28 @@ def replace_AssignImplicit(dag, solver_hooks):
         new_phases[phase_name] = phase.copy(statements=new_statements)
 
     return dag.copy(phases=new_phases)
+
+
+def generate_solve(cb, unknowns, equations, var_to_unknown, guess):
+
+    # got a square system, let's solve
+    assignees = [unk.name for unk in unknowns]
+
+    from pymbolic import substitute
+    subst_dict = {
+            rhs_var.name: var_to_unknown[rhs_var]
+            for rhs_var in unknowns}
+
+    cb.assign_implicit(
+            assignees=assignees,
+            solve_components=[
+                var_to_unknown[unk].name
+                for unk in unknowns],
+            expressions=[
+                substitute(eq, subst_dict)
+                for eq in equations],
+
+            # TODO: Could supply a starting guess
+            other_params={
+                "guess": guess},
+            solver_id="solve")

--- a/leap/multistep/__init__.py
+++ b/leap/multistep/__init__.py
@@ -381,16 +381,6 @@ class AdamsMethodBuilder(MethodBuilder):
 # {{{ ab method
 
 class AdamsBashforthMethodBuilder(AdamsMethodBuilder):
-    """
-    User-supplied context:
-
-        <state> + component_id: The value that is integrated
-        <func> + component_id: The right hand side
-
-    .. automethod:: __init__
-    .. automethod:: generate
-    """
-
     def generate_primary(self, cb):
         rhs_var = var("rhs_var")
         from pytools import UniqueNameGenerator
@@ -469,15 +459,6 @@ class AdamsBashforthMethodBuilder(AdamsMethodBuilder):
 
 
 class AdamsMoultonMethodBuilder(AdamsMethodBuilder):
-    """
-    User-supplied context:
-        <state> + component_id: The value that is integrated
-        <func> + component_id: The right hand side
-
-    .. automethod:: __init__
-    .. automethod:: generate
-    """
-
     def generate_primary(self, cb):
 
         from pytools import UniqueNameGenerator

--- a/leap/multistep/__init__.py
+++ b/leap/multistep/__init__.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 import numpy as np
 import numpy.linalg as la
-from leap import MethodBuilder
+from leap import MethodBuilder, TwoOrderAdaptiveMethodBuilderMixin
 from pymbolic import var
 
 
@@ -590,6 +590,217 @@ class AdamsMoultonMethodBuilder(AdamsMethodBuilder):
             bootstrap_length = self.hist_length
         else:
             bootstrap_length = self.hist_length - 1
+
+        return bootstrap_length
+
+# }}}
+
+
+# {{{ embedded method w/adaptivity
+
+
+class EmbeddedAdamsMethodBuilder(
+        AdamsMethodBuilder, TwoOrderAdaptiveMethodBuilderMixin):
+    """
+    User-supplied context:
+      <state> + component_id: The value that is integrated
+      <func> + component_id: The right hand side function
+    """
+
+    def __init__(self, component_id, function_family=None, state_filter_name=None,
+            hist_length=None, static_dt=False, order=None, _extra_bootstrap=False,
+            use_high_order=False, atol=0, rtol=0, max_dt_growth=None,
+            min_dt_shrinkage=None):
+        """
+        :arg function_family: Accepts an instance of
+            :class:`AdamsIntegrationFunctionFamily`
+            or an integer, in which case the classical monomial function family
+            with the order given by the integer is used.
+        :arg static_dt: If *True*, changing the timestep during time integration
+            is not allowed.
+        """
+
+        if function_family is not None and order is not None:
+            raise ValueError("may not specify both function_family and order")
+
+        function_families = []
+        if function_family is None:
+            function_families.append(order)
+            function_families.append(order + 1)
+            self.low_order = order
+            self.high_order = order + 1
+            del order
+        else:
+            function_families.append(function_family)
+            function_families.append(function_family + 1)
+            self.low_order = function_family
+            self.high_order = function_family + 1
+
+        self.function_families = []
+        self.function_families.append(
+                AdamsMonomialIntegrationFunctionFamily(function_families[0]))
+        self.function_families.append(
+                AdamsMonomialIntegrationFunctionFamily(function_families[1]))
+
+        if hist_length is None:
+            hist_length = function_families[0] + 1
+
+        # Check for reasonable history length.
+        if hist_length < function_families[0] + 1:
+            raise ValueError("Invalid history length specified for embedded Adams")
+
+        self.hist_length = hist_length
+
+        # If adaptivity is on, we can't have a static timestep.
+        if atol or rtol:
+            if static_dt is True:
+                raise ValueError("Can't have static timestepping with adaptivity")
+
+        self.static_dt = static_dt
+        self.extra_bootstrap = _extra_bootstrap
+
+        self.component_id = component_id
+
+        # Declare variables
+        self.step = var("<p>step")
+        self.function = var("<func>" + component_id)
+        self.history = \
+            [var("<p>f_n_minus_" + str(i)) for i in range(hist_length - 1, 0, -1)]
+
+        if not self.static_dt:
+            self.time_history = [
+                    var("<p>t_n_minus_" + str(i))
+                    for i in range(hist_length - 1, 0, -1)]
+
+        self.state = var("<state>" + component_id)
+        self.t = var("<t>")
+        self.dt = var("<dt>")
+
+        self.state_filter_name = state_filter_name
+        if state_filter_name is not None:
+            self.state_filter = var("<func>" + state_filter_name)
+        else:
+            self.state_filter = None
+
+        TwoOrderAdaptiveMethodBuilderMixin.__init__(
+                self,
+                atol=atol,
+                rtol=rtol,
+                max_dt_growth=max_dt_growth,
+                min_dt_shrinkage=min_dt_shrinkage)
+
+        self.use_high_order = use_high_order
+
+    def generate_primary(self, cb):
+
+        from pytools import UniqueNameGenerator
+        name_gen = UniqueNameGenerator()
+        array = var("<builtin>array")
+        rhs_var = var("rhs_var")
+
+        # This fills the full (higher-order) history.
+        time_history_data, time_hist, \
+                dt_factor, t_end = self.set_up_time_history(cb, self.t)
+
+        cb(rhs_var, self.eval_rhs(self.t, self.state))
+        history = self.history + [rhs_var]
+
+        # Create history to feed to AB.
+        history_ab = history[:-1]
+        time_hist_ab_var = var(name_gen("time_history_ab"))
+        cb(time_hist_ab_var, array(self.hist_length-1))
+        for i in range(self.hist_length-1):
+            cb(time_hist_ab_var[i], time_hist[i])
+
+        time_hist_ab = time_hist_ab_var
+
+        # Set up the actual Adams-Bashforth steps.
+        ab_sum = emit_adams_integration(
+                        cb, name_gen,
+                        self.function_families[0],
+                        time_hist_ab, history_ab,
+                        0, t_end)
+
+        ab_sum_high = emit_adams_integration(
+                        cb, name_gen,
+                        self.function_families[1],
+                        time_hist, history,
+                        0, t_end)
+
+        state_est_low = self.state + dt_factor * ab_sum
+        state_est_high = self.state + dt_factor * ab_sum_high
+
+        # Apply state filters
+        if self.state_filter is not None:
+            state_est_low = self.state_filter(state_est_low)
+            state_est_high = self.state_filter(state_est_high)
+
+        # Finish needs to intervene here.
+        self.finish(cb, state_est_high, state_est_low, history, time_history_data)
+
+    def finish(self, cb, high_est, low_est, hist, time_hist):
+        if not self.adaptive:
+            cb(self.state, low_est)
+            # Rotate history and time history.
+            self.rotate_and_yield(cb, hist, time_hist)
+        else:
+            self.finish_adaptive_adams(cb, high_est, low_est, hist, time_hist)
+
+    def finish_nonadaptive_adams(self, cb, high_order_estimate,
+                           low_order_estimate, hist, time_hist):
+        if self.use_high_order:
+            est = high_order_estimate
+        else:
+            est = low_order_estimate
+
+        cb(self.state, est)
+        # Rotate history and time history.
+        self.rotate_and_yield(cb, hist, time_hist)
+
+    def rk_bootstrap(self, cb):
+        """Initialize the timestepper with an RK method."""
+
+        rhs_var = var("rhs_var")
+
+        cb(rhs_var, self.eval_rhs(self.t, self.state))
+
+        # Save the current RHS to the AB history
+
+        for i in range(len(self.history)):
+            with cb.if_(self.step, "==", i + 1):
+                cb(self.history[i], rhs_var)
+
+                if not self.static_dt:
+                    cb(self.time_history[i], self.t)
+
+        from leap.rk import ORDER_TO_RK_METHOD_BUILDER
+        rk_method = ORDER_TO_RK_METHOD_BUILDER[self.function_families[0].order]
+        rk_coeffs = rk_method.output_coeffs
+        stage_coeff_set_names = ("explicit",)
+        stage_coeff_sets = {"explicit": rk_method.a_explicit}
+        estimate_coeff_set_names = ("main",)
+        estimate_coeff_sets = {"main": rk_coeffs}
+        rhs_funcs = {"explicit": var("<func>"+self.component_id)}
+
+        # Traverse RK stage loop of appropriate order and update state.
+        rk = rk_method(self.component_id, self.state_filter_name)
+        cb = rk.generate_butcher_init(cb, stage_coeff_set_names,
+                                      stage_coeff_sets, rhs_funcs,
+                                      estimate_coeff_set_names,
+                                      estimate_coeff_sets)
+        cb, rhss, est_vars = rk.generate_butcher_primary(cb, stage_coeff_set_names,
+                                                         stage_coeff_sets, rhs_funcs,
+                                                         estimate_coeff_set_names,
+                                                         estimate_coeff_sets)
+
+        # Assign the value of the new state.
+        cb(self.state, est_vars[0])
+
+    def determine_bootstrap_length(self):
+
+        # In the explicit case, this is always
+        # equal to history length.
+        bootstrap_length = self.hist_length
 
         return bootstrap_length
 

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -200,7 +200,7 @@ class ButcherTableauMethodBuilder(MethodBuilder):
                     "primary": cb_primary.as_execution_phase(next_phase="primary")
                     },
                 initial_phase="initial")
-    
+
     # {{{ initialization
 
     def generate_butcher_init(self, cb, stage_coeff_set_names,
@@ -555,6 +555,7 @@ ORDER_TO_RK_METHOD_BUILDER = {
 
 # }}}
 
+
 # {{{ implicit butcher tableau methods
 
 
@@ -605,7 +606,7 @@ class DIRK2MethodBuilder(ImplicitButcherTableauMethodBuilder):
     Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
     Methods for Ordinary Differential Equations. A Review
     pp. 72, eqn 221
-    
+
     .. automethod:: __init__
     .. automethod:: generate
     """
@@ -629,7 +630,7 @@ class DIRK3MethodBuilder(ImplicitButcherTableauMethodBuilder):
     Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
     Methods for Ordinary Differential Equations. A Review
     pp. 77, eqn 229 & eqn 230
-    
+
     .. automethod:: __init__
     .. automethod:: generate
     """
@@ -654,7 +655,7 @@ class DIRK4MethodBuilder(ImplicitButcherTableauMethodBuilder):
     Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
     Methods for Ordinary Differential Equations. A Review
     pp. 78, eqn 232
-    
+
     .. automethod:: __init__
     .. automethod:: generate
     """
@@ -680,7 +681,7 @@ class DIRK5MethodBuilder(ImplicitButcherTableauMethodBuilder):
     Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
     Methods for Ordinary Differential Equations. A Review
     pp. 98, Table 24
-    
+
     .. automethod:: __init__
     .. automethod:: generate
     """
@@ -717,7 +718,9 @@ IMPLICIT_ORDER_TO_RK_METHOD_BUILDER = {
 
 # }}}
 
+
 # {{{ Embedded Runge-Kutta schemes base class
+
 
 class EmbeddedButcherTableauMethodBuilder(
         ButcherTableauMethodBuilder, TwoOrderAdaptiveMethodBuilderMixin):

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -134,6 +134,10 @@ class ButcherTableauMethodBuilder(MethodBuilder):
         raise NotImplementedError
 
     @property
+    def a_implicit(self):
+        raise NotImplementedError
+
+    @property
     def output_coeffs(self):
         raise NotImplementedError
 

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -39,8 +39,12 @@ __doc__ = """
     A dictionary mapping desired order of accuracy to a corresponding RK method
     builder.
 
+.. data:: IMPLICIT_ORDER_TO_RK_METHOD_BUILDER
+
+    A dictionary mapping desired order of accuracy to a corresponding implicit
+    RK method builder.
+
 .. autoclass:: ForwardEulerMethodBuilder
-.. autoclass:: BackwardEulerMethodBuilder
 .. autoclass:: MidpointMethodBuilder
 .. autoclass:: HeunsMethodBuilder
 .. autoclass:: RK3MethodBuilder
@@ -64,6 +68,15 @@ Strong Stability Preserving (SSP) Methods
 .. autoclass:: SSPRKMethodBuilder
 .. autoclass:: SSPRK22MethodBuilder
 .. autoclass:: SSPRK33MethodBuilder
+
+Implicit Methods
+-----------------------------------------
+
+.. autoclass:: BackwardEulerMethodBuilder
+.. autoclass:: DIRK2MethodBuilder
+.. autoclass:: DIRK3MethodBuilder
+.. autoclass:: DIRK4MethodBuilder
+.. autoclass:: DIRK5MethodBuilder
 """
 
 
@@ -140,6 +153,198 @@ class ButcherTableauMethodBuilder(MethodBuilder):
         else:
             self.state_filter = None
 
+    # {{{ initialization
+
+    def generate_butcher_init(self, cb, stage_coeff_set_names,
+            stage_coeff_sets, rhs_funcs, estimate_coeff_set_names,
+            estimate_coeff_sets):
+        self.last_rhss = {}
+        from pymbolic import var
+        for name in stage_coeff_set_names:
+            if (
+                    name in self.recycle_last_stage_coeff_set_names
+                    and _is_first_stage_same_as_last_stage(
+                    self.c, stage_coeff_sets[name])):
+                self.last_rhss[name] = var("<p>last_rhs_" + name)
+                cb(self.last_rhss[name], rhs_funcs[name](
+                    t=self.t, **{self.component_id: self.state}))
+
+        cb_init = cb
+
+        return cb_init
+
+    # }}}
+
+    # {{{ stage loop
+
+    def generate_butcher_primary(self, cb, stage_coeff_set_names,
+            stage_coeff_sets, rhs_funcs, estimate_coeff_set_names,
+            estimate_coeff_sets):
+
+        last_state_est_var = cb.fresh_var("last_state_est")
+        last_state_est_var_valid = False
+
+        equations = []
+        unknowns = set()
+
+        comp = self.component_id
+        nstages = len(self.c)
+        dt = self.dt
+        t = self.t
+        last_rhss = self.last_rhss
+
+        stage_rhs_vars = {}
+        rhs_var_to_unknown = {}
+        for name in stage_coeff_set_names:
+            stage_rhs_vars[name] = [
+                    cb.fresh_var(f"rhs_{name}_s{i}") for i in range(len(self.c))]
+
+            # These are rhss if they are not yet known and pending an implicit solve.
+            for i, rhsvar in enumerate(stage_rhs_vars[name]):
+                unkvar = cb.fresh_var(f"unk_{name}_s{i}")
+                rhs_var_to_unknown[rhsvar] = unkvar
+
+        knowns = set()
+
+        def make_known(v):
+            unknowns.discard(v)
+            knowns.add(v)
+
+        for istage in range(len(self.c)):
+            for name in stage_coeff_set_names:
+                c = self.c[istage]
+                my_rhs = stage_rhs_vars[name][istage]
+
+                if (
+                        name in self.recycle_last_stage_coeff_set_names
+                        and istage == 0
+                        and _is_first_stage_same_as_last_stage(
+                            self.c, stage_coeff_sets[name])):
+                    cb(my_rhs, last_rhss[name])
+                    make_known(my_rhs)
+
+                else:
+                    is_implicit = False
+
+                    state_increment = 0
+                    for src_name in stage_coeff_set_names:
+                        coeffs = stage_coeff_sets[src_name][istage]
+                        for src_istage, coeff in enumerate(coeffs):
+                            rhsval = stage_rhs_vars[src_name][src_istage]
+                            if rhsval not in knowns:
+                                unknowns.add(rhsval)
+                                is_implicit = True
+
+                            state_increment += dt * coeff * rhsval
+
+                    state_est = self.state + state_increment
+                    if (self.state_filter is not None
+                            and not (
+                                # reusing last output state
+                                c == 0
+                                and all(
+                                    len(stage_coeff_sets[src_name][istage]) == 0
+                                    for src_name in stage_coeff_set_names))):
+                        state_est = self.state_filter(state_est)
+
+                    if is_implicit:
+                        rhs_expr = rhs_funcs[name](
+                                t=t + c*dt, **{comp: state_est})
+
+                        from dagrt.expression import collapse_constants
+                        solve_expression = collapse_constants(
+                                my_rhs - rhs_expr,
+                                list(unknowns) + [self.state],
+                                cb.assign, cb.fresh_var)
+                        equations.append(solve_expression)
+
+                        if istage + 1 == nstages:
+                            last_state_est_var_valid = False
+
+                    else:
+                        if istage + 1 == nstages:
+                            cb(last_state_est_var, state_est)
+                            state_est = last_state_est_var
+                            last_state_est_var_valid = True
+
+                        rhs_expr = rhs_funcs[name](
+                                t=t + c*dt, **{comp: state_est})
+
+                        cb(my_rhs, rhs_expr)
+                        make_known(my_rhs)
+
+                # {{{ emit solve if possible
+
+                if unknowns and len(unknowns) == len(equations):
+                    from leap.implicit import generate_solve
+                    generate_solve(cb, unknowns, equations, rhs_var_to_unknown,
+                                    self.state)
+
+                del equations[:]
+                knowns.update(unknowns)
+                unknowns.clear()
+
+                # }}}
+
+        # Compute solution estimates.
+        estimate_vars = [
+                cb.fresh_var("est_"+name)
+                for name in estimate_coeff_set_names]
+
+        for iest, name in enumerate(estimate_coeff_set_names):
+            out_coeffs = estimate_coeff_sets[name]
+
+            if (
+                    last_state_est_var_valid
+                    and  # noqa: W504
+                    _is_last_stage_same_as_output(self.c,
+                        stage_coeff_sets, out_coeffs)):
+                state_est = last_state_est_var
+
+            else:
+                state_increment = 0
+                for src_name in stage_coeff_set_names:
+                    state_increment += sum(
+                                coeff * stage_rhs_vars[src_name][src_istage]
+                                for src_istage, coeff in enumerate(out_coeffs))
+
+                state_est = self.state + dt*state_increment
+
+                if self.state_filter is not None:
+                    state_est = self.state_filter(state_est)
+
+            cb(
+                estimate_vars[iest],
+                state_est)
+
+        cb_primary = cb
+
+        return cb_primary, stage_rhs_vars, estimate_vars
+
+    def generate_butcher_finish(self, cb, stage_coeff_set_names,
+            stage_coeff_sets, rhs_funcs, estimate_coeff_set_names,
+            estimate_coeff_sets, stage_rhs_vars, estimate_vars):
+
+        last_rhss = self.last_rhss
+
+        # This updates <t>.
+        self.finish(cb, estimate_coeff_set_names, estimate_vars)
+
+        # These updates have to happen *after* finish because before we
+        # don't yet know whether finish will accept the new state.
+        for name in stage_coeff_set_names:
+            if (
+                    name in self.recycle_last_stage_coeff_set_names
+                    and _is_first_stage_same_as_last_stage(
+                        self.c, stage_coeff_sets[name])):
+                cb(last_rhss[name], stage_rhs_vars[name][-1])
+
+        cb_primary = cb
+
+        return cb_primary
+
+    # }}}
+
     def generate_butcher(self, stage_coeff_set_names, stage_coeff_sets, rhs_funcs,
             estimate_coeff_set_names, estimate_coeff_sets):
         """
@@ -153,210 +358,33 @@ class ButcherTableauMethodBuilder(MethodBuilder):
         :arg estimate_coeffs_sets: a mapping from estimate coefficient set
             names to cofficients.
         """
-
-        from pymbolic import var
-        comp = self.component_id
-
-        dt = self.dt
-        t = self.t
-        state = self.state
-
-        nstages = len(self.c)
-
         # {{{ check coefficients for plausibility
 
         for name in stage_coeff_set_names:
-            for istage in range(nstages):
+            for istage in range(len(self.c)):
                 coeff_sum = sum(stage_coeff_sets[name][istage])
                 assert abs(coeff_sum - self.c[istage]) < 1e-12, (
                         name, istage, coeff_sum, self.c[istage])
 
         # }}}
 
-        # {{{ initialization
-
-        last_rhss = {}
-
-        with CodeBuilder(name="initialization") as cb:
-            for name in stage_coeff_set_names:
-                if (
-                        name in self.recycle_last_stage_coeff_set_names
-                        and _is_first_stage_same_as_last_stage(
-                        self.c, stage_coeff_sets[name])):
-                    last_rhss[name] = var("<p>last_rhs_" + name)
-                    cb(last_rhss[name], rhs_funcs[name](t=t, **{comp: state}))
-
-        cb_init = cb
-
-        # }}}
-
-        stage_rhs_vars = {}
-        rhs_var_to_unknown = {}
-        for name in stage_coeff_set_names:
-            stage_rhs_vars[name] = [
-                    cb.fresh_var(f"rhs_{name}_s{i}") for i in range(nstages)]
-
-            # These are rhss if they are not yet known and pending an implicit solve.
-            for i, rhsvar in enumerate(stage_rhs_vars[name]):
-                unkvar = cb.fresh_var(f"unk_{name}_s{i}")
-                rhs_var_to_unknown[rhsvar] = unkvar
-
-        knowns = set()
-
-        # {{{ stage loop
-
-        last_state_est_var = cb.fresh_var("last_state_est")
-        last_state_est_var_valid = False
-
-        with CodeBuilder(name="primary") as cb:
-            equations = []
-            unknowns = set()
-
-            def make_known(v):
-                unknowns.discard(v)
-                knowns.add(v)
-
-            for istage in range(nstages):
-                for name in stage_coeff_set_names:
-                    c = self.c[istage]
-                    my_rhs = stage_rhs_vars[name][istage]
-
-                    if (
-                            name in self.recycle_last_stage_coeff_set_names
-                            and istage == 0
-                            and _is_first_stage_same_as_last_stage(
-                                self.c, stage_coeff_sets[name])):
-                        cb(my_rhs, last_rhss[name])
-                        make_known(my_rhs)
-
-                    else:
-                        is_implicit = False
-
-                        state_increment = 0
-                        for src_name in stage_coeff_set_names:
-                            coeffs = stage_coeff_sets[src_name][istage]
-                            for src_istage, coeff in enumerate(coeffs):
-                                rhsval = stage_rhs_vars[src_name][src_istage]
-                                if rhsval not in knowns:
-                                    unknowns.add(rhsval)
-                                    is_implicit = True
-
-                                state_increment += dt * coeff * rhsval
-
-                        state_est = state + state_increment
-                        if (self.state_filter is not None
-                                and not (
-                                    # reusing last output state
-                                    c == 0
-                                    and all(
-                                        len(stage_coeff_sets[src_name][istage]) == 0
-                                        for src_name in stage_coeff_set_names))):
-                            state_est = self.state_filter(state_est)
-
-                        if is_implicit:
-                            rhs_expr = rhs_funcs[name](
-                                    t=t + c*dt, **{comp: state_est})
-
-                            from dagrt.expression import collapse_constants
-                            solve_expression = collapse_constants(
-                                    my_rhs - rhs_expr,
-                                    list(unknowns) + [self.state],
-                                    cb.assign, cb.fresh_var)
-                            equations.append(solve_expression)
-
-                            if istage + 1 == nstages:
-                                last_state_est_var_valid = False
-
-                        else:
-                            if istage + 1 == nstages:
-                                cb(last_state_est_var, state_est)
-                                state_est = last_state_est_var
-                                last_state_est_var_valid = True
-
-                            rhs_expr = rhs_funcs[name](
-                                    t=t + c*dt, **{comp: state_est})
-
-                            cb(my_rhs, rhs_expr)
-                            make_known(my_rhs)
-
-                    # {{{ emit solve if possible
-
-                    if unknowns and len(unknowns) == len(equations):
-                        # got a square system, let's solve
-                        assignees = [unk.name for unk in unknowns]
-
-                        from pymbolic import substitute
-                        subst_dict = {
-                                rhs_var.name: rhs_var_to_unknown[rhs_var]
-                                for rhs_var in unknowns}
-
-                        cb.assign_implicit(
-                                assignees=assignees,
-                                solve_components=[
-                                    rhs_var_to_unknown[unk].name
-                                    for unk in unknowns],
-                                expressions=[
-                                    substitute(eq, subst_dict)
-                                    for eq in equations],
-
-                                # TODO: Could supply a starting guess
-                                other_params={
-                                    "guess": state},
-                                solver_id="solve")
-
-                        del equations[:]
-                        knowns.update(unknowns)
-                        unknowns.clear()
-
-                    # }}}
-
-            # Compute solution estimates.
-            estimate_vars = [
-                    cb.fresh_var("est_"+name)
-                    for name in estimate_coeff_set_names]
-
-            for iest, name in enumerate(estimate_coeff_set_names):
-                out_coeffs = estimate_coeff_sets[name]
-
-                if (
-                        last_state_est_var_valid
-                        and  # noqa: W504
-                        _is_last_stage_same_as_output(self.c,
-                            stage_coeff_sets, out_coeffs)):
-                    state_est = last_state_est_var
-
-                else:
-                    state_increment = 0
-                    for src_name in stage_coeff_set_names:
-                        state_increment += sum(
-                                    coeff * stage_rhs_vars[src_name][src_istage]
-                                    for src_istage, coeff in enumerate(out_coeffs))
-
-                    state_est = state + dt*state_increment
-
-                    if self.state_filter is not None:
-                        state_est = self.state_filter(state_est)
-
-                cb(
-                        estimate_vars[iest],
-                        state_est)
-
-            # This updates <t>.
-            self.finish(cb, estimate_coeff_set_names, estimate_vars)
-
-            # These updates have to happen *after* finish because before we
-            # don't yet know whether finish will accept the new state.
-            for name in stage_coeff_set_names:
-                if (
-                        name in self.recycle_last_stage_coeff_set_names
-                        and _is_first_stage_same_as_last_stage(
-                            self.c, stage_coeff_sets[name])):
-                    cb(last_rhss[name], stage_rhs_vars[name][-1])
-
-        cb_primary = cb
-
-        # }}}
-
+        cb_init = CodeBuilder(name="initialization")
+        cb_init = self.generate_butcher_init(cb_init, stage_coeff_set_names,
+                                              stage_coeff_sets, rhs_funcs,
+                                              estimate_coeff_set_names,
+                                              estimate_coeff_sets)
+        cb_primary = CodeBuilder(name="primary")
+        cb_primary, stage_rhs_vars, estimate_vars,  = self.generate_butcher_primary(
+                                              cb_primary, stage_coeff_set_names,
+                                              stage_coeff_sets, rhs_funcs,
+                                              estimate_coeff_set_names,
+                                              estimate_coeff_sets)
+        cb_primary = self.generate_butcher_finish(cb_primary, stage_coeff_set_names,
+                                              stage_coeff_sets, rhs_funcs,
+                                              estimate_coeff_set_names,
+                                              estimate_coeff_sets,
+                                              stage_rhs_vars,
+                                              estimate_vars)
         return DAGCode(
                 phases={
                     "initial": cb_init.as_execution_phase(next_phase="primary"),
@@ -400,6 +428,22 @@ class SimpleButcherTableauMethodBuilder(ButcherTableauMethodBuilder):
                     })
 
 
+class ImplicitButcherTableauMethodBuilder(SimpleButcherTableauMethodBuilder):
+    def generate(self):
+        """
+        :returns: :class:`dagrt.language.DAGCode`
+        """
+        return self.generate_butcher(
+                stage_coeff_set_names=("implicit",),
+                stage_coeff_sets={
+                    "implicit": self.a_implicit},
+                rhs_funcs={"implicit": var(self.rhs_func_name)},
+                estimate_coeff_set_names=("main",),
+                estimate_coeff_sets={
+                    "main": self.output_coeffs,
+                    })
+
+
 class ForwardEulerMethodBuilder(SimpleButcherTableauMethodBuilder):
     """
     .. automethod:: __init__
@@ -421,9 +465,9 @@ class BackwardEulerMethodBuilder(SimpleButcherTableauMethodBuilder):
     .. automethod:: __init__
     .. automethod:: generate
     """
-    c = (0,)
+    c = (1,)
 
-    a_explicit = (
+    a_implicit = (
             (1,),
             )
 
@@ -528,6 +572,109 @@ class RK5MethodBuilder(SimpleButcherTableauMethodBuilder):
     recycle_last_stage_coeff_set_names = ()
 
 
+class DIRK2MethodBuilder(ImplicitButcherTableauMethodBuilder):
+    """
+    .. automethod:: __init__
+    .. automethod:: generate
+    Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
+            Methods for Ordinary Differential Equations. A Review
+            pp. 72, eqn 221
+    """
+
+    _x = (2 - np.sqrt(2))/2
+
+    c = (_x, 1)
+
+    a_implicit = (
+            (_x,),
+            (1 - _x, _x,),
+            )
+
+    output_coeffs = (1 - _x, _x)
+
+    recycle_last_stage_coeff_set_names = ()
+
+
+class DIRK3MethodBuilder(ImplicitButcherTableauMethodBuilder):
+    """
+    .. automethod:: __init__
+    .. automethod:: generate
+    Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
+            Methods for Ordinary Differential Equations. A Review
+            pp. 77, eqn 229 & eqn 230
+    """
+
+    _x = 0.4358665215
+
+    c = (_x, (1 + _x)/2, 1)
+
+    a_implicit = (
+            (_x,),
+            ((1 - _x)/2, _x,),
+            (-3*_x**2/2 + 4*_x - 0.25, 3*_x**2/2 - 5*_x + 5/4, _x,),
+            )
+
+    output_coeffs = (-3*_x**2/2 + 4*_x - 0.25, 3*_x**2/2 - 5*_x + 5/4, _x)
+
+    recycle_last_stage_coeff_set_names = ()
+
+
+class DIRK4MethodBuilder(ImplicitButcherTableauMethodBuilder):
+    """
+    .. automethod:: __init__
+    .. automethod:: generate
+    Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
+            Methods for Ordinary Differential Equations. A Review
+            pp. 78, eqn 232
+    """
+
+    _x1 = 1.06858
+
+    c = (_x1, 1/2, 1 - _x1)
+
+    a_implicit = (
+            (_x1,),
+            (1/2 - _x1, _x1,),
+            (2*_x1, 1 - 4*_x1, _x1),
+            )
+
+    output_coeffs = (1/(6*(1 - 2*_x1)**2), (3*(1 - 2*_x1)**2 - 1)/(3*(1 - 2*_x1)**2),
+                     1/(6*(1 - 2*_x1)**2))
+
+    recycle_last_stage_coeff_set_names = ()
+
+
+class DIRK5MethodBuilder(ImplicitButcherTableauMethodBuilder):
+    """
+    .. automethod:: __init__
+    .. automethod:: generate
+    Source: Kennedy & Carpenter: Diagonally Implicit Runge-Kutta
+            Methods for Ordinary Differential Equations. A Review
+            pp. 98, Table 24
+    """
+
+    c = (4024571134387/14474071345096, 5555633399575/5431021154178,
+         5255299487392/12852514622453, 3/20, 10449500210709/14474071345096)
+
+    a_implicit = (
+            (4024571134387/14474071345096,),
+            (9365021263232/12572342979331, 4024571134387/14474071345096,),
+            (2144716224527/9320917548702, -397905335951/4008788611757,
+             4024571134387/14474071345096,),
+            (-291541413000/6267936762551, 226761949132/4473940808273,
+             -1282248297070/9697416712681, 4024571134387/14474071345096,),
+            (-2481679516057/4626464057815, -197112422687/6604378783090,
+             3952887910906/9713059315593, 4906835613583/8134926921134,
+             4024571134387/14474071345096,),
+            )
+
+    output_coeffs = (-2522702558582/12162329469185, 1018267903655/12907234417901,
+                     4542392826351/13702606430957, 5001116467727/12224457745473,
+                     1509636094297/3891594770934)
+
+    recycle_last_stage_coeff_set_names = ()
+
+
 ORDER_TO_RK_METHOD_BUILDER = {
         1: ForwardEulerMethodBuilder,
         2: MidpointMethodBuilder,
@@ -535,6 +682,15 @@ ORDER_TO_RK_METHOD_BUILDER = {
         4: RK4MethodBuilder,
         5: RK5MethodBuilder,
         }
+
+IMPLICIT_ORDER_TO_RK_METHOD_BUILDER = {
+        1: BackwardEulerMethodBuilder,
+        2: DIRK2MethodBuilder,
+        3: DIRK3MethodBuilder,
+        4: DIRK4MethodBuilder,
+        5: DIRK4MethodBuilder,
+        }
+
 
 # }}}
 

--- a/test/test_adams.py
+++ b/test/test_adams.py
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 import sys
 import pytest
-from leap.multistep import AdamsBashforthMethodBuilder
+from leap.multistep import AdamsBashforthMethodBuilder, AdamsMoultonMethodBuilder
 
 from utils import (  # noqa
         python_method_impl_interpreter as pmi_int,
@@ -51,6 +51,24 @@ def test_ab_accuracy(python_method_impl, method, expected_order,
     check_simple_convergence(method=method, method_impl=python_method_impl,
                              expected_order=expected_order, show_dag=show_dag,
                              plot_solution=plot_solution)
+
+
+@pytest.mark.parametrize(("method", "expected_order"), [
+    (AdamsMoultonMethodBuilder("y", order, static_dt=static_dt), order)
+    for order in [1, 3, 5]
+    for static_dt in [True, False]
+    ] + [
+    (AdamsMoultonMethodBuilder("y", order, hist_length=order+1,
+        static_dt=static_dt), order)
+    for order in [1, 3, 5]
+    for static_dt in [True, False]
+    ])
+def test_am_accuracy(python_method_impl, method, expected_order,
+        show_dag=False, plot_solution=False):
+    from utils import check_simple_convergence
+    check_simple_convergence(method=method, method_impl=python_method_impl,
+                             expected_order=expected_order, show_dag=show_dag,
+                             plot_solution=plot_solution, implicit=True)
 
 
 if __name__ == "__main__":

--- a/test/test_embedded_adams.py
+++ b/test/test_embedded_adams.py
@@ -1,0 +1,209 @@
+#! /usr/bin/env python
+
+__copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+# avoid spurious: pytest.mark.parametrize is not callable
+# pylint: disable=not-callable
+
+import sys
+import pytest
+
+from leap.multistep import EmbeddedAdamsMethodBuilder
+import numpy as np
+
+import logging
+
+from utils import (  # noqa
+        python_method_impl_interpreter as pmi_int,
+        python_method_impl_codegen as pmi_cg)
+
+logger = logging.getLogger(__name__)
+
+
+# {{{ non-adaptive test
+
+@pytest.mark.parametrize(("method", "expected_order"), [
+    (EmbeddedAdamsMethodBuilder("y", order=2, use_high_order=False), 2),
+    (EmbeddedAdamsMethodBuilder("y", order=3, use_high_order=False), 3),
+    (EmbeddedAdamsMethodBuilder("y", order=4, use_high_order=False), 4),
+    ])
+def test_embedded_accuracy(python_method_impl, method, expected_order,
+                     show_dag=False, plot_solution=False):
+    from utils import check_simple_convergence
+    check_simple_convergence(method=method, method_impl=python_method_impl,
+                             expected_order=expected_order, show_dag=show_dag,
+                             plot_solution=plot_solution, implicit=False)
+
+# }}}
+
+# {{{ adaptive test
+
+
+@pytest.mark.parametrize(("method", "ss_frac", "ss_targ", "bs_frac", "bs_targ"), [
+    (EmbeddedAdamsMethodBuilder("y", order=2, rtol=1e-6), 0.4, 0.005, 0.15, 0.01),
+    (EmbeddedAdamsMethodBuilder("y", order=3, rtol=1e-6), 0.35, 0.001, 0.16, 0.005),
+    (EmbeddedAdamsMethodBuilder("y", order=4, rtol=1e-6), 0.35, 0.0001, 0.16, 0.001),
+    ])
+def test_adaptive_timestep(python_method_impl, method, ss_frac, bs_frac,
+                           ss_targ, bs_targ, show_dag=False, plot=False):
+    from utils import check_adaptive_timestep
+    check_adaptive_timestep(python_method_impl=python_method_impl, method=method,
+                             ss_frac=ss_frac, bs_frac=bs_frac, ss_targ=ss_targ,
+                             bs_targ=bs_targ, show_dag=show_dag, plot=plot,
+                             implicit=True)
+
+
+@pytest.mark.parametrize(("method", "expected_order"),  [
+    (EmbeddedAdamsMethodBuilder("y", order=2, rtol=1e-6), 2),
+    (EmbeddedAdamsMethodBuilder("y", order=3, rtol=1e-6), 3),
+    (EmbeddedAdamsMethodBuilder("y", order=4, rtol=1e-6), 4),
+    ])
+def test_adaptive_accuracy(method, expected_order, show_dag=False,
+                           plot=False, python_method_impl=pmi_cg):
+    # Use "DEBUG" to trace execution
+    logging.basicConfig(level=logging.INFO)
+
+    component_id = method.component_id
+    code = method.generate()
+
+    code_nonadapt = EmbeddedAdamsMethodBuilder("y", order=expected_order).generate()
+
+    if show_dag:
+        from dagrt.language import show_dependency_graph
+        show_dependency_graph(code)
+
+    from stiff_test_systems import VanDerPolProblem
+    example = VanDerPolProblem()
+    y = example.initial()
+
+    interp = python_method_impl(code,
+                                function_map={"<func>" + component_id: example})
+
+    interp_nonadapt = python_method_impl(code_nonadapt,
+                                function_map={"<func>" + component_id: example})
+
+    interp.set_up(t_start=example.t_start, dt_start=1e-5, context={component_id: y})
+
+    times = []
+    values = []
+
+    new_times = []
+    new_values = []
+
+    last_t = 0
+    step_sizes = []
+    nsteps = []
+    istep = 0
+
+    # Initial run to establish step sizes.
+    for event in interp.run(t_end=example.t_end/10.0):
+        if isinstance(event, interp.StateComputed):
+            assert event.component_id == component_id
+
+            new_values.append(event.state_component)
+            new_times.append(event.t)
+        elif isinstance(event, interp.StepCompleted):
+            if not new_times:
+                continue
+
+            istep += 1
+            step_sizes.append(event.t - last_t)
+            last_t = event.t
+
+            times.extend(new_times)
+            values.extend(new_values)
+            del new_times[:]
+            del new_values[:]
+        elif isinstance(event, interp.StepFailed):
+            del new_times[:]
+            del new_values[:]
+
+            logger.info("failed step at t=%s" % event.t)
+
+    times = np.array(times)
+    values = np.array(values)
+    step_sizes = np.array(step_sizes)
+    nsteps = len(step_sizes)
+    final_time = times[-1]
+    final_val = values[-1]
+    end_vals = []
+    end_vals.append(final_val)
+    dts = []
+    dts.append(10.0/nsteps)
+    from pytools.convergence import EOCRecorder
+    eocrec = EOCRecorder()
+    for i in range(1, 5):
+        fac = 2**i
+        nsteps_run = fac*nsteps
+        dt = np.zeros(nsteps_run)
+
+        for j in range(0, nsteps_run, fac):
+            dt[j] = step_sizes[int(j/fac)]/fac
+            for k in range(1, fac):
+                dt[j+k] = step_sizes[int(j/fac)]/fac
+
+        # Now that we have our new set of timesteps, do the run,
+        # same as before, but with adaptivity turned off.
+        interp_nonadapt.set_up(t_start=example.t_start, dt_start=dt[0],
+                               context={component_id: y})
+        iout = 1
+        for event in interp_nonadapt.run(t_end=final_time):
+            if isinstance(event, interp_nonadapt.StateComputed):
+                assert event.component_id == component_id
+
+                end_val = event.state_component
+            elif isinstance(event, interp_nonadapt.StepCompleted):
+                if iout < nsteps*fac:
+                    if event.t + dt[iout] >= final_time:
+                        interp_nonadapt.dt = final_time - event.t
+                    else:
+                        interp_nonadapt.dt = dt[iout]
+                    iout += 1
+                else:
+                    interp_nonadapt.dt = final_time - event.t
+
+        end_vals.append(end_val)
+        dts.append(10.0/iout)
+
+    # Now calculate errors using the final time as the
+    # true solution (self-convergence)
+    for i in range(1, 5):
+        eocrec.add_data_point(dts[i-1],
+                              np.linalg.norm(end_vals[i-1] - end_vals[-1]))
+
+    print(eocrec.pretty_print())
+    orderest = eocrec.estimate_order_of_convergence()[0, 1]
+    assert orderest > 0.9 * expected_order
+
+
+# }}}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: filetype=pyopencl:fdm=marker

--- a/test/utils.py
+++ b/test/utils.py
@@ -38,6 +38,20 @@ def python_method_impl_codegen(code, **kwargs):
 # }}}
 
 
+def solver(f, t, sub_y, coeff, guess):
+    from scipy.optimize import root
+    return root(lambda unk: unk - f(t=t, y=sub_y + coeff*unk), guess).x
+
+
+def solver_hook(solve_expr, solve_var, solver_id, guess):
+    from dagrt.expression import match, substitute
+
+    pieces = match("unk - <func>rhs(t=t, y=sub_y + coeff*unk)", solve_expr,
+                   pre_match={"unk": solve_var})
+    pieces["guess"] = guess
+    return substitute("<func>solver(t, sub_y, coeff, guess)", pieces)
+
+
 def execute_and_return_single_result(python_method_impl, code, initial_context={},
                                      max_steps=1):
     interpreter = python_method_impl(code, function_map={})
@@ -95,7 +109,7 @@ _default_dts = 2 ** -np.array(range(4, 7), dtype=np.float64)  # noqa pylint:disa
 
 def check_simple_convergence(method, method_impl, expected_order,
                              problem=DefaultProblem(), dts=_default_dts,
-                             show_dag=False, plot_solution=False):
+                             show_dag=False, plot_solution=False, implicit=False):
     component_id = method.component_id
     code = method.generate()
     print(code)
@@ -103,6 +117,10 @@ def check_simple_convergence(method, method_impl, expected_order,
     if show_dag:
         from dagrt.language import show_dependency_graph
         show_dependency_graph(code)
+
+    if implicit:
+        from leap.implicit import replace_AssignImplicit
+        code = replace_AssignImplicit(code, {"solve": solver_hook})
 
     from pytools.convergence import EOCRecorder
     eocrec = EOCRecorder()
@@ -112,9 +130,16 @@ def check_simple_convergence(method, method_impl, expected_order,
         y = problem.initial()
         final_t = problem.t_end
 
-        interp = method_impl(code, function_map={
-            "<func>" + component_id: problem,
-            })
+        if implicit:
+            from functools import partial
+            interp = method_impl(code, function_map={
+                "<func>" + component_id: problem,
+                "<func>solver": partial(solver, problem),
+                })
+        else:
+            interp = method_impl(code, function_map={
+                "<func>" + component_id: problem,
+                })
         interp.set_up(t_start=t, dt_start=dt, context={component_id: y})
 
         times = []

--- a/test/utils.py
+++ b/test/utils.py
@@ -21,6 +21,9 @@ THE SOFTWARE.
 """
 
 import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 # {{{ things to pass for python_method_impl
@@ -112,7 +115,7 @@ def check_simple_convergence(method, method_impl, expected_order,
                              show_dag=False, plot_solution=False, implicit=False):
     component_id = method.component_id
     code = method.generate()
-    print(code)
+    #print(code)
 
     if show_dag:
         from dagrt.language import show_dependency_graph
@@ -171,6 +174,93 @@ def check_simple_convergence(method, method_impl, expected_order,
 
     orderest = eocrec.estimate_order_of_convergence()[0, 1]
     assert orderest > expected_order * 0.9
+
+
+def check_adaptive_timestep(python_method_impl, method, ss_frac, bs_frac,
+                            ss_targ, bs_targ, show_dag=False, plot=False,
+                            implicit=False):
+    # Use "DEBUG" to trace execution
+    logging.basicConfig(level=logging.INFO)
+
+    component_id = method.component_id
+    code = method.generate()
+    #print(code)
+    #1/0
+
+    if implicit:
+        from leap.implicit import replace_AssignImplicit
+        code = replace_AssignImplicit(code, {"solve": solver_hook})
+
+    if show_dag:
+        from dagrt.language import show_dependency_graph
+        show_dependency_graph(code)
+
+    from stiff_test_systems import VanDerPolProblem
+    example = VanDerPolProblem()
+    y = example.initial()
+
+    if implicit:
+        from functools import partial
+        interp = python_method_impl(code,
+                                    function_map={"<func>" + component_id: example,
+                                    "<func>solver": partial(solver, example)})
+    else:
+        interp = python_method_impl(code,
+                                    function_map={"<func>" + component_id: example})
+    interp.set_up(t_start=example.t_start, dt_start=1e-5, context={component_id: y})
+
+    times = []
+    values = []
+
+    new_times = []
+    new_values = []
+
+    last_t = 0
+    step_sizes = []
+
+    for event in interp.run(t_end=example.t_end/4.0):
+        if isinstance(event, interp.StateComputed):
+            assert event.component_id == component_id
+
+            new_values.append(event.state_component)
+            new_times.append(event.t)
+        elif isinstance(event, interp.StepCompleted):
+            if not new_times:
+                continue
+
+            step_sizes.append(event.t - last_t)
+            last_t = event.t
+
+            times.extend(new_times)
+            values.extend(new_values)
+            del new_times[:]
+            del new_values[:]
+        elif isinstance(event, interp.StepFailed):
+            del new_times[:]
+            del new_values[:]
+
+            logger.info("failed step at t=%s" % event.t)
+
+    times = np.array(times)
+    values = np.array(values)
+    step_sizes = np.array(step_sizes)
+
+    if plot:
+        import matplotlib.pyplot as pt
+        pt.clf()
+        pt.plot(times, values[:, 1], "x-")
+        pt.show()
+        pt.plot(times, step_sizes, "x-")
+        pt.show()
+
+    step_sizes = np.array(step_sizes)
+    small_step_frac = len(np.nonzero(step_sizes < ss_targ)[0]) / len(step_sizes)
+    big_step_frac = len(np.nonzero(step_sizes > bs_targ)[0]) / len(step_sizes)
+
+    print("small_step_frac (<%g): %g - big_step_frac (>%g): %g"
+            % (ss_targ, small_step_frac, bs_targ, big_step_frac))
+    assert small_step_frac <= ss_frac, small_step_frac
+    assert big_step_frac >= bs_frac, big_step_frac
 
 
 # vim: foldmethod=marker


### PR DESCRIPTION
This PR provides an alternative (or perhaps an addition) to the branch detailed in [this pull request](https://github.com/inducer/leap/pull/11). This adds an embedded Adams method that performs adaptive timestepping by using explicit estimates of multiple orders to form the local error estimate (rather than using an implicit-explicit pair, as in the linked pull request).