### PR TITLE
WIP: Adaptive BDF/NDF in Leap

### DIFF
--- a/leap/__init__.py
+++ b/leap/__init__.py
@@ -155,6 +155,134 @@ class TwoOrderAdaptiveMethodBuilderMixin(MethodBuilder):
 # }}}
 
 
+# {{{ adaptivity w/order changing
+
+class AdaptiveOrderMethodBuilderMixin(MethodBuilder):
+    """
+    This class expected the following members to be defined: state, t, dt.
+    """
+
+    def __init__(self, atol=0, rtol=0, max_dt_growth=None,
+                 min_dt_shrinkage=None, error_const=None):
+        self.adaptive = bool(atol or rtol)
+        self.atol = atol
+        self.rtol = rtol
+
+        if max_dt_growth is None:
+            max_dt_growth = 5
+
+        if min_dt_shrinkage is None:
+            min_dt_shrinkage = 0.1
+
+        self.max_dt_growth = max_dt_growth
+        self.min_dt_shrinkage = min_dt_shrinkage
+
+        self.error_const = error_const
+
+    def finish_nonadaptive(self, cb, high_order_estimate, low_order_estimate):
+        raise NotImplementedError()
+
+    def rotate_history(self, cb, high_order_estimate, low_order_estimate):
+        raise NotImplementedError()
+
+    def rescale_interval(self, cb):
+        raise NotImplementedError()
+
+    def finish_adaptive(self, cb, high_order_estimate, low_order_estimate,
+                        hist, order, factor, equal_steps):
+        from pymbolic import var
+        from pymbolic.primitives import Comparison, LogicalOr, Max, Min
+        from dagrt.expression import IfThenElse
+
+        rel_error_raw = var("rel_error_raw")
+        rel_error = var("rel_error")
+        rel_error_p1 = var("rel_error_p1")
+        rel_error_m1 = var("rel_error_m1")
+        factor_p1 = var("factor_p1")
+        factor_m1 = var("factor_m1")
+
+        def norm(expr):
+            return var("<builtin>norm_2")(expr)
+
+        def weighted_norm(expr1, expr2, expr3, atol, rtol):
+            return var("<builtin>norm_wrms")(expr1, expr2, expr3, atol, rtol)
+
+        cb(rel_error_raw, weighted_norm(
+            self.error_const[order]*(high_order_estimate - low_order_estimate),
+            self.state, high_order_estimate, self.atol, self.rtol))
+
+        cb(rel_error, IfThenElse(Comparison(rel_error_raw, "==", 0),
+                                 1.0e-14, rel_error_raw))
+
+        with cb.if_(LogicalOr((Comparison(rel_error, ">", 1),
+                               var("<builtin>isnan")(rel_error)))):
+
+            with cb.if_(var("<builtin>isnan")(rel_error)):
+                cb(self.dt, self.min_dt_shrinkage * self.dt)
+            with cb.else_():
+                # Default Scipy BDF safety factor.
+                cb(self.dt, Max((0.81 * self.dt
+                    * rel_error ** (-1.0 / (order + 1)),
+                    self.min_dt_shrinkage * self.dt)))
+                cb(factor, Max((0.81
+                    * rel_error ** (-1.0 / (order + 1)),
+                    self.min_dt_shrinkage)))
+                self.rescale_interval(cb)
+                cb(self.dt_monitor, self.dt)
+                cb(equal_steps, 0)
+            with cb.if_(self.t + self.dt, "==", self.t):
+                cb.raise_(TimeStepUnderflow)
+            with cb.else_():
+                cb.fail_step()
+
+        with cb.else_():
+            # Rotate state history.
+            self.rotate_history(cb, high_order_estimate, low_order_estimate)
+            cb(equal_steps, equal_steps+1)
+            cb(factor, 1)
+            cb(factor_p1, 0)
+            cb(factor_m1, 0)
+            with cb.if_(Comparison(equal_steps, ">=", order+1)):
+
+                # Now we need to use the history to determine if we should
+                # update order.
+                with cb.if_(Comparison(order, ">", 1)):
+                    cb(rel_error_m1, weighted_norm(
+                        self.error_const[order-1]*hist[order],
+                        self.state, high_order_estimate, self.atol,
+                        self.rtol))
+                    cb(factor_m1, 0.81
+                        * rel_error_m1 ** (-1.0 / (order)))
+                with cb.else_():
+                    cb(factor_m1, 0)
+                with cb.if_(Comparison(order, "<", 5)):
+                    cb(rel_error_p1, weighted_norm(
+                        self.error_const[order+1]*hist[order+2],
+                        self.state, high_order_estimate, self.atol,
+                        self.rtol))
+                    cb(factor_p1, 0.81
+                        * rel_error_p1 ** (-1.0 / (order + 2)))
+                with cb.else_():
+                    cb(rel_error_p1, 0)
+                # Based on these new error norms, do we modify the order?
+                cb(factor, 0.81 * rel_error ** (-1.0 / (order + 1)))
+                cb(factor, Max((factor, factor_p1, factor_m1)))
+                with cb.if_(Comparison(factor, "==", factor_p1)):
+                    cb(order, order + 1)
+                with cb.if_(Comparison(factor, "==", factor_m1)):
+                    cb(order, order - 1)
+                cb(factor, Min((self.max_dt_growth, factor)))
+                self.rescale_interval(cb)
+                cb(equal_steps, 0)
+            # This updates <t>: <dt> should not be set before this is called.
+            self.finish_nonadaptive(cb, high_order_estimate,
+                                    low_order_estimate)
+            cb(self.dt, self.dt * factor)
+            cb(self.dt_monitor, self.dt)
+
+# }}}
+
+
 # {{{ diagnostics
 
 class TimeStepUnderflow(RuntimeError):

--- a/leap/multistep/__init__.py
+++ b/leap/multistep/__init__.py
@@ -29,7 +29,7 @@ THE SOFTWARE.
 
 import numpy as np
 import numpy.linalg as la
-from leap import MethodBuilder
+from leap import MethodBuilder, AdaptiveOrderMethodBuilderMixin
 from pymbolic import var
 
 
@@ -37,6 +37,7 @@ __doc__ = """
 .. autoclass:: AdamsIntegrationFunctionFamily
 .. autoclass:: AdamsMonomialIntegrationFunctionFamily
 .. autoclass:: AdamsBashforthMethodBuilder
+.. autoclass:: AdaptiveBDFMethodBuilder
 """
 
 
@@ -202,6 +203,73 @@ def emit_adams_extrapolation(cb, name_gen,
     return _emit_func_family_operation(
             cb, name_gen, function_family, time_values, hist_vars,
             lambda i: function_family.evaluate(i, t_eval))
+
+# }}}
+
+# {{{ BDF/NDF helper functions
+
+
+def emit_R_computation(cb, order, factor, name_gen):
+    """Compute the matrix for changing the differences array.
+
+    Source: Shampine, Lawrence F., and Mark W. Reichelt.
+    "The matlab ode suite." Section 2.2"""
+    array = var("<builtin>array")
+    k = var(name_gen("m_k"))
+    i = var(name_gen("I"))
+    cb(i, array(order))
+    cb(i[k-1], k, loops=[(k.name, 1, order+1)])
+    # I = np.arange(1, order + 1)[:, None]
+    j = var(name_gen("J"))
+    cb(j, array(order))
+    cb(j[k-1], k, loops=[(k.name, 1, order+1)])
+    # J = np.arange(1, order + 1)
+    m = var(name_gen("M"))
+    cb(m, array((order + 1)*(order + 1)))
+    # M = np.zeros((order + 1, order + 1))
+    l_ind = var(name_gen("m_l"))
+    cb(m[k + l_ind*(order+1)], 0,
+        loops=[(l_ind.name, 0, order+1), (k.name, 0, order+1)])
+    cb(m[k+1 + (l_ind+1)*(order+1)], (i[l_ind] - 1 - factor * j[k]) / i[l_ind],
+        loops=[(l_ind.name, 0, order), (k.name, 0, order)])
+    cb(m[l_ind], 1, loops=[(l_ind.name, 0, order+1)])
+    # M[1:, 1:] = (I - 1 - factor * J) / I
+    cumprod = var("<builtin>cumulative_product")
+    reshape = var("<builtin>reshape")
+    transpose = var("<builtin>transpose")
+    r = var(name_gen("R"))
+    cb(r, cumprod(reshape(transpose(m, order+1), order+1), 0))
+    # return np.cumprod(M, axis=0)
+    return r
+
+
+def change_D(cb, d, order, factor):
+    """Change differences array in-place when step size is changed.
+    Source: Shampine, Lawrence F., and Mark W. Reichelt.
+    "The matlab ode suite." Section 2.2"""
+    from pytools import UniqueNameGenerator
+    name_gen = UniqueNameGenerator()
+    r = emit_R_computation(cb, order, factor, name_gen)
+    u = emit_R_computation(cb, order, 1, name_gen)
+    ru = var(name_gen("RU"))
+    matmul = var("<builtin>matmul")
+    usr_matmul = var("<builtin>user_matmul")
+    transpose = var("<builtin>transpose")
+    cb(ru, matmul(r, u, order+1, order+1))
+    # RU = R.dot(U)
+    j = var(name_gen("m_j"))
+    n = var(name_gen("n"))
+    cb(n, var("<builtin>len")(d[0]))
+    # Need to take subset of history here, then we'll reassign after.
+    array_utype = var("<builtin>array_utype")
+    d_in = var(name_gen("D_in"))
+    cb(d_in, array_utype(order+1, d[0]))
+    cb(d_in[j], d[j], loops=[(j.name, 0, order+1)])
+    cb(d_in, usr_matmul(transpose(ru, order+1), d_in, order+1,
+        var("<builtin>len")(d[0]), var("<builtin>len")(d[0])))
+    cb(d[j], d_in[j], loops=[(j.name, 0, order+1)])
+    # D[:order + 1] = np.dot(RU.T, D[:order + 1])
+
 
 # }}}
 
@@ -413,6 +481,280 @@ class AdamsBashforthMethodBuilder(MethodBuilder):
 
         # Assign the value of the new state.
         cb(self.state, state_est)
+
+# }}}
+
+# {{{ Scipy-esque adaptive BDF/NDF
+
+
+class AdaptiveBDFMethodBuilder(AdaptiveOrderMethodBuilderMixin):
+    """
+    Source: Shampine, Lawrence F., and Mark W. Reichelt.
+    "The matlab ode suite." SIAM journal on scientific
+    computing 18.1 (1997): 1-22.
+
+    User-supplied context:
+      <state> + component_id: The value that is integrated
+      <func> + component_id: The right hand side function
+    """
+
+    def __init__(self, component_id, state_filter_name=None, fixed_order=None,
+            use_high_order=True, atol=0, rtol=0, max_dt_growth=None,
+            min_dt_shrinkage=None, ndf=False):
+
+        # For adaptive BDF/NDF, we fix maximum order of 5.
+        self.max_order = 5
+
+        self.component_id = component_id
+
+        # Declare variables
+        self.step = var("<p>step")
+        self.step_factor = var("<p>step_factor")
+        self.equal_steps = var("<p>equal_steps")
+        self.order = var("<p>order")
+        self.function = var("<func>" + component_id)
+        self.history = var("<p>hist")
+        self.kappa = var("<p>kappa")
+        self.gamma = var("<p>gamma")
+        self.alpha = var("<p>alpha")
+        self.dt_monitor = var("<p>dt_monitor")
+        self.error_const = var("<p>error_const")
+
+        self.state = var("<state>" + component_id)
+        self.t = var("<t>")
+        self.dt = var("<dt>")
+
+        self.ndf = ndf
+
+        self.state_filter_name = state_filter_name
+        if state_filter_name is not None:
+            self.state_filter = var("<func>" + state_filter_name)
+        else:
+            self.state_filter = None
+
+        AdaptiveOrderMethodBuilderMixin.__init__(
+                self,
+                atol=atol,
+                rtol=rtol,
+                max_dt_growth=max_dt_growth,
+                min_dt_shrinkage=min_dt_shrinkage,
+                error_const=self.error_const)
+
+        self.atol = atol
+        self.rtol = rtol
+        self.use_high_order = use_high_order
+
+    def eval_rhs(self, t, y):
+        """Return a node that evaluates the RHS at the given time and
+        component value."""
+        from pymbolic.primitives import CallWithKwargs
+        return CallWithKwargs(function=self.function,
+                              parameters=(),
+                              kw_parameters={"t": t, self.component_id: y})
+
+    def generate(self):
+        """
+        :returns: :class:`dagrt.language.DAGCode`
+        """
+
+        from dagrt.language import DAGCode, CodeBuilder
+
+        # Initialization
+        with CodeBuilder(name="initialization") as cb_init:
+            j = var("j")
+            rhs_dummy = var("rhs_dummy")
+            array = var("<builtin>array")
+            array_utype = var("<builtin>array_utype")
+            cb_init(self.kappa, array(6))
+            cb_init(self.gamma, array(6))
+            cb_init(self.alpha, array(6))
+            cb_init(self.error_const, array(6))
+            cb_init(self.history, array_utype(8, self.state))
+            cb_init(self.order, 1)
+            cb_init(self.equal_steps, 0)
+            # NDF vs. BDF:
+            if self.ndf:
+                # Optimized for minimal truncation error.
+                cb_init(self.kappa[0], 0)
+                cb_init(self.kappa[1], -0.1850)
+                cb_init(self.kappa[2], -1/9)
+                cb_init(self.kappa[3], -0.0823)
+                cb_init(self.kappa[4], -0.0415)
+                cb_init(self.kappa[5], 0)
+                cb_init(self.error_const[0], 1)
+                cb_init(self.error_const[1], 0.315)
+                cb_init(self.error_const[2], 0.16666667)
+                cb_init(self.error_const[3], 0.09911667)
+                cb_init(self.error_const[4], 0.11354167)
+                cb_init(self.error_const[5], 0.16666667)
+            else:
+                cb_init(self.kappa[j], 0, loops=[(j.name, 0, 5)])
+                cb_init(self.error_const[0], 1)
+                cb_init(self.error_const[1], 0.5)
+                cb_init(self.error_const[2], 0.33333333)
+                cb_init(self.error_const[3], 0.25)
+                cb_init(self.error_const[4], 0.2)
+                cb_init(self.error_const[5], 0.16666667)
+            cb_init(self.gamma[0], 0)
+            cb_init(self.gamma[1], 1)
+            cb_init(self.gamma[2], 1.5)
+            cb_init(self.gamma[3], 1.83333333)
+            cb_init(self.gamma[4], 2.08333333)
+            cb_init(self.gamma[5], 2.28333333)
+            cb_init(self.alpha, (1 - self.kappa) * self.gamma)
+            cb_init(self.history[0], self.state)
+            cb_init(rhs_dummy, self.dt * self.eval_rhs(self.t, self.state))
+            cb_init(self.history[1], rhs_dummy)
+            cb_init(self.step, 1)
+            cb_init(self.dt_monitor, self.dt)
+
+        # Primary
+        with CodeBuilder(name="primary") as cb_primary:
+            self.generate_primary(cb_primary)
+
+        # Based on an initialization at first order, and with
+        # a predictor-corrector formulation, we require no
+        # bootstrapping.
+        return DAGCode(
+            phases={
+                "initial": cb_init.as_execution_phase(next_phase="primary"),
+                "primary": cb_primary.as_execution_phase(next_phase="primary")
+                },
+            initial_phase="initial")
+
+    def rotate_history(self, cb, state_est_high, state_est_low):
+        # Rotate the history.
+        i = var("i")
+        cb(self.history[self.order + 2], (state_est_high - state_est_low)
+                - self.history[self.order + 1])
+        cb(self.history[self.order + 1], (state_est_high - state_est_low))
+        cb(self.history[self.order-i], self.history[self.order-i]
+                + self.history[self.order+1-i],
+                loops=[(i.name, 0, self.order+1)])
+
+    def rescale_interval(self, cb):
+        # Incorporate the scaling change
+        # required when the timestep changes.
+        change_D(cb, self.history, self.order, self.step_factor)
+
+    def yield_state(self, cb):
+        # Update state and time.
+        cb(self.t, self.t + self.dt)
+        cb.yield_state(expression=self.state,
+                               component_id=self.component_id,
+                               time_id="", time=self.t)
+
+    def generate_primary(self, cb):
+
+        from pytools import UniqueNameGenerator
+        name_gen = UniqueNameGenerator()
+        rhs_next_var = var("rhs_next_var")
+        rhs_var_to_unknown = {}
+        unkvar = cb.fresh_var("unk")
+        rhs_var_to_unknown[rhs_next_var] = unkvar
+        equations = []
+        unknowns = set()
+        knowns = set()
+
+        unknowns.add(rhs_next_var)
+
+        # First, check to see if dt got modified out from
+        # under us in order to adhere to some end time.
+        from pymbolic.primitives import Comparison
+        with cb.if_(Comparison(self.dt, "!=", self.dt_monitor)):
+            cb(self.step_factor, self.dt/self.dt_monitor)
+            cb(self.dt_monitor, self.dt)
+            self.rescale_interval(cb)
+
+        # Use existing scaled histories to form prediction.
+        j = var(name_gen("m_j"))
+        y_predict = var("y_predict")
+        cb(y_predict, self.history[0])
+        cb(y_predict, y_predict + self.history[j],
+            loops=[(j.name, 1, self.order+1)])
+
+        state_est_low = y_predict
+
+        # Form expression(s) for correction.
+        psi = var("psi")
+        cb(psi, 0)
+        cb(psi, psi + (1 / self.alpha[self.order])
+                * self.gamma[j]*self.history[j],
+                loops=[(j.name, 1, self.order+1)])
+        state_est_high = (self.dt / self.alpha[self.order]) * \
+                rhs_next_var - psi + state_est_low
+
+        # Build the implicit solve expression.
+        from dagrt.expression import collapse_constants
+        from pymbolic.mapper.distributor import DistributeMapper as DistMap
+        solve_expression = collapse_constants(
+                rhs_next_var - self.eval_rhs(self.t + self.dt,
+                                             DistMap()(state_est_high)),
+                list(unknowns) + [self.state],
+                cb.assign, cb.fresh_var)
+        equations.append(solve_expression)
+
+        # {{{ emit solve if possible
+
+        if unknowns and len(unknowns) == len(equations):
+            # got a square system, let's solve
+            assignees = [unk.name for unk in unknowns]
+
+            from pymbolic import substitute
+            subst_dict = {
+                    rhs_var.name: rhs_var_to_unknown[rhs_var]
+                    for rhs_var in unknowns}
+
+            cb.assign_implicit(
+                    assignees=assignees,
+                    solve_components=[
+                        rhs_var_to_unknown[unk].name
+                        for unk in unknowns],
+                    expressions=[
+                        substitute(eq, subst_dict)
+                        for eq in equations],
+
+                    # TODO: Could supply a starting guess
+                    other_params={
+                        "guess": state_est_low},
+                    solver_id="solve")
+
+            del equations[:]
+            knowns.update(unknowns)
+            unknowns.clear()
+        elif len(unknowns) > len(equations):
+            raise ValueError("BDF/NDF implicit timestep has more "
+                    "unknowns than equations")
+        elif len(unknowns) < len(equations):
+            raise ValueError("BDF/NDF implicit timestep has more "
+                    "equations than unknowns")
+
+        # }}}
+
+        # Update the state now that we've solved.
+        if self.state_filter is not None:
+            state_est_low = self.state_filter(state_est_low)
+            state_est_high = self.state_filter(state_est_high)
+
+        self.finish(cb, state_est_high, state_est_low)
+
+    def finish(self, cb, high_est, low_est):
+        if not self.adaptive:
+            self.rotate_history(cb, high_est, low_est)
+            self.finish_nonadaptive(cb, high_est, low_est)
+        else:
+            self.finish_adaptive(cb, high_est, low_est, self.history,
+                                 self.order, self.step_factor,
+                                 self.equal_steps)
+
+    def finish_nonadaptive(self, cb, high_est, low_est):
+        if self.use_high_order:
+            est = high_est
+        else:
+            est = low_est
+
+        cb(self.state, est)
+        self.yield_state(cb)
 
 # }}}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 git+https://github.com/inducer/pytools.git
 git+https://github.com/inducer/pymbolic.git
-git+https://github.com/inducer/dagrt.git
+git+https://github.com/cmikida2/dagrt.git@bdf-builtins

--- a/test/test_bdf.py
+++ b/test/test_bdf.py
@@ -1,0 +1,200 @@
+#! /usr/bin/env python
+
+__copyright__ = "Copyright (C) 2014 Andreas Kloeckner"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+# avoid spurious: pytest.mark.parametrize is not callable
+# pylint: disable=not-callable
+
+import sys
+
+from leap.multistep import AdaptiveBDFMethodBuilder
+import numpy as np
+import scipy.linalg as la
+
+import logging
+
+from utils import (  # noqa
+        python_method_impl_interpreter as pmi_int,
+        python_method_impl_codegen as pmi_cg)
+
+logger = logging.getLogger(__name__)
+
+
+def VDPJac(t, y):
+    jac = np.zeros((2, 2))
+    mu = 30
+    jac[0, 0] = 0
+    jac[0, 1] = 1
+    jac[1, 0] = -2*mu*y[0]*y[1] - 1
+    jac[1, 1] = -mu*(y[0]*y[0] - 1)
+    return jac
+
+
+def newton_solver(t, sub_y, coeff, guess):
+
+    from stiff_test_systems import VanDerPolProblem
+    vdp = VanDerPolProblem()
+    d = 0
+    corr_norm = 1.0
+    reltol = 1e-6
+    abstol = 0
+    y_old = guess.copy()
+    y_guess = guess.copy()
+    corr_weights = np.zeros(2)
+    # Match Scipy BDF
+    newton_tol = 0.01
+    newton_maxiter = 4
+    corr_norm_old = None
+    converged = False
+    # Try pulling this out of the loop.
+    jac = VDPJac(t, y_old)
+    lu = la.lu_factor(np.eye(2) - coeff*jac, overwrite_a=True)
+    # Check convergence w/weighted norm...
+    for j in range(0, 2):
+        corr_weights[j] = (reltol * np.abs(y_old[j]) + abstol)
+    psi = -(sub_y - guess)
+    for i in range(newton_maxiter):
+        rhs = vdp(t, y_guess)
+        corr = la.lu_solve(lu, coeff*rhs - psi - d, overwrite_b=True)
+        y_guess += corr
+        d += corr
+        # RMS norm:
+        corr_norm = np.linalg.norm(corr / corr_weights) / 2 ** 0.5
+        if corr_norm_old is not None:
+            rate = corr_norm / corr_norm_old
+        else:
+            rate = None
+        if rate is not None and rate / (1 - rate) * corr_norm < newton_tol:
+            converged = True
+            break
+        corr_norm_old = corr_norm
+
+    if converged is False:
+        raise ValueError("Newton failed to converge")
+
+    # Return RHS that gives y_n+1 = y_guess
+    return (y_guess + psi - y_old)/coeff
+
+
+def solver_hook(solve_expr, solve_var, solver_id, guess):
+    from dagrt.expression import match, substitute
+
+    pieces = match("unk - <func>rhs(t=t, y=sub_y + coeff*unk)", solve_expr,
+                    pre_match={"unk": solve_var})
+    pieces["guess"] = guess
+    return substitute("<func>solver(t, sub_y, coeff, guess)", pieces)
+
+
+# {{{ adaptive test
+
+def test_adaptive_timestep(python_method_impl, show_dag=False,
+                           plot=True):
+    # Use "DEBUG" to trace execution
+    logging.basicConfig(level=logging.INFO)
+
+    method = AdaptiveBDFMethodBuilder("y", rtol=1e-6)
+    component_id = method.component_id
+    code = method.generate()
+
+    from leap.implicit import replace_AssignImplicit
+    code = replace_AssignImplicit(code, {"solve": solver_hook})
+
+    if show_dag:
+        from dagrt.language import show_dependency_graph
+        show_dependency_graph(code)
+
+    from stiff_test_systems import VanDerPolProblem
+    example = VanDerPolProblem()
+    y = example.initial()
+
+    interp = python_method_impl(code,
+                                function_map={"<func>" + component_id: example,
+                                              "<func>solver": newton_solver,
+                                              })
+    interp.set_up(t_start=example.t_start, dt_start=1e-5, context={component_id: y})
+
+    times = []
+    values = []
+
+    new_times = []
+    new_values = []
+
+    last_t = 0
+    step_sizes = []
+
+    for event in interp.run(t_end=example.t_end):
+        if isinstance(event, interp.StateComputed):
+            assert event.component_id == component_id
+
+            new_values.append(event.state_component)
+            new_times.append(event.t)
+        elif isinstance(event, interp.StepCompleted):
+            if not new_times:
+                continue
+
+            step_sizes.append(event.t - last_t)
+            last_t = event.t
+
+            times.extend(new_times)
+            values.extend(new_values)
+            del new_times[:]
+            del new_values[:]
+        elif isinstance(event, interp.StepFailed):
+            del new_times[:]
+            del new_values[:]
+
+            logger.info("failed step at t=%s" % event.t)
+
+    times = np.array(times)
+    values = np.array(values)
+    step_sizes = np.array(step_sizes)
+
+    if plot:
+        import matplotlib.pyplot as pt
+        pt.plot(times, values[:, 1], "x-")
+        pt.title("Van Der Pol: State 2")
+        pt.show()
+        pt.plot(times, step_sizes, "x-")
+        pt.title("Van Der Pol: Step Sizes")
+        pt.show()
+
+    step_sizes = np.array(step_sizes)
+    small_step_frac = len(np.nonzero(step_sizes < 0.01)[0]) / len(step_sizes)
+    big_step_frac = len(np.nonzero(step_sizes > 0.05)[0]) / len(step_sizes)
+
+    print("small_step_frac (<0.01): %g - big_step_frac (>.05): %g"
+            % (small_step_frac, big_step_frac))
+    assert small_step_frac <= 0.7, small_step_frac
+    assert big_step_frac >= 0.16, big_step_frac
+
+# }}}
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: filetype=pyopencl:fdm=marker


### PR DESCRIPTION
Aims to implement the order and timestep adaptive backward differentiation formulas/numerical differentiation formulas as Leap timesteppers. The method here matches that of [MATLAB ode15s](https://www.mathworks.com/help/matlab/ref/ode15s.html) and Scipy's [`integrate.bdf`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.integrate.BDF.html). In particular, [this paper](https://www.researchgate.net/publication/2331331_The_matlab_ODE_suite) from Shampine and Reichelt describes the method well.