### PR TITLE
Remove use of deprecated `np.object`

### DIFF
--- a/leap/step_matrix.py
+++ b/leap/step_matrix.py
@@ -204,7 +204,7 @@ class StepMatrixFinder:
         nv = len(components)
         shape = (nv, nv)
         if not sparse:
-            step_matrix = np.zeros(shape, dtype=np.object)
+            step_matrix = np.zeros(shape, dtype=object)
         else:
             indices = []
             data = []

--- a/test/test_step_matrix.py
+++ b/test/test_step_matrix.py
@@ -152,7 +152,7 @@ def test_step_matrix_vector_state(show_matrix=True, show_dag=False):
 
     # XXX: brittle
     dt = var("<dt>")
-    true_mat = np.eye(3, dtype=np.object) + dt * J
+    true_mat = np.eye(3, dtype=object) + dt * J
     assert (mat == true_mat).all()
 
 
@@ -201,7 +201,7 @@ def test_step_matrix_sparse():
     assert mat.shape == (3, 3)
     # https://github.com/PyCQA/pylint/issues/3388
     assert mat.indices == [(0, 0), (1, 1), (2, 2)]  # pylint: disable=no-member
-    true_mat = np.eye(3, dtype=np.object) + dt * J
+    true_mat = np.eye(3, dtype=object) + dt * J
     assert (mat.data == np.diag(true_mat)).all()
 
     eval_mat = fast_evaluator(mat, sparse=True)


### PR DESCRIPTION
Broken by numpy 1.24 after having been deprecated for a wile.