### PR TITLE
Remove pytools.Record

### DIFF
--- a/examples/adaptive-rk/adaptive-rk.py
+++ b/examples/adaptive-rk/adaptive-rk.py
@@ -14,7 +14,9 @@ The same functionality is supported using leap.rk.ODE23MethodBuilder.
 """
 
 import logging
+
 import numpy as np
+
 
 logging.basicConfig(level=logging.INFO)
 

--- a/examples/imex/imex.py
+++ b/examples/imex/imex.py
@@ -84,8 +84,9 @@ def solver_hook(solve_expr, solve_var, solver_id, guess):
 
 
 def run():
-    from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
     from dagrt.codegen import PythonCodeGenerator
+
+    from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
 
     # Construct the method generator.
     mgen = KennedyCarpenterIMEXARK4MethodBuilder("y", atol=_atol)

--- a/examples/implicit_euler/implicit_euler.py
+++ b/examples/implicit_euler/implicit_euler.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 """Implicit Euler timestepper"""
 
-from leap import MethodBuilder
-from dagrt.language import DAGCode, CodeBuilder
+from dagrt.language import CodeBuilder, DAGCode
 from pymbolic import var
 from pymbolic.primitives import CallWithKwargs
+
+from leap import MethodBuilder
+
 
 __copyright__ = "Copyright (C) 2014 Matt Wala"
 

--- a/examples/implicit_euler/test_implicit_euler.py
+++ b/examples/implicit_euler/test_implicit_euler.py
@@ -1,8 +1,9 @@
 #! /usr/bin/env python
 
-import pytest
 import sys
+
 import numpy as np
+import pytest
 
 
 __copyright__ = "Copyright (C) 2014 Andreas Kloeckner, Matt Wala"

--- a/examples/rk/run_rk_method.py
+++ b/examples/rk/run_rk_method.py
@@ -26,8 +26,9 @@ THE SOFTWARE.
 """
 
 
-from leap.rk import ODE23MethodBuilder
 import numpy as np
+
+from leap.rk import ODE23MethodBuilder
 
 
 def main(show_dag=False, plot_solution=False):

--- a/examples/semi-implicit-rk/semi-implicit-rk.py
+++ b/examples/semi-implicit-rk/semi-implicit-rk.py
@@ -11,8 +11,9 @@ Source:
 """
 
 
-import numpy as np
 import logging
+
+import numpy as np
 
 
 logging.basicConfig(level=logging.INFO)

--- a/examples/stability/mr-max-eigvals.py
+++ b/examples/stability/mr-max-eigvals.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 
 import matplotlib
+
+
 matplotlib.use("Agg")  # noqa
 
+from functools import partial
+
+import matplotlib.pyplot as pt
 import numpy as np
 import numpy.linalg as la
+
 from leap.multistep.multirate import TwoRateAdamsBashforthMethodBuilder
-import matplotlib.pyplot as pt
-from functools import partial
 
 
 def process_eigval(evaluate_mat, speed_factor, prec, major_eigval):
@@ -26,9 +30,9 @@ def process_eigval(evaluate_mat, speed_factor, prec, major_eigval):
 
 
 def main():
-    from leap.step_matrix import StepMatrixFinder
-
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     speed_factor = 10
     method_name = "Fq"

--- a/examples/stability/mr-stability-diagram.py
+++ b/examples/stability/mr-stability-diagram.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python
 
 import matplotlib
+
+
 matplotlib.use("Agg")  # noqa
 
+import matplotlib.pyplot as pt
 import numpy as np
 import numpy.linalg as la
+
 from leap.multistep.multirate import TwoRateAdamsBashforthMethodBuilder
-import matplotlib.pyplot as pt
 
 
 def main():
-    from leap.step_matrix import StepMatrixFinder
-
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     speed_factor = 10
     method_name = "Fq"
@@ -65,8 +68,9 @@ def main():
 
             return (np.abs(eigvals) <= 1 + tol).all()
 
-        from leap.stability import find_truth_bdry
         from functools import partial
+
+        from leap.stability import find_truth_bdry
 
         points = []
 

--- a/examples/stability/multirate-step-matrix.py
+++ b/examples/stability/multirate-step-matrix.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 import numpy as np
 import numpy.linalg as la
+
 from leap.multistep.multirate import TwoRateAdamsBashforthMethodBuilder
 
 
 def main():
-    from leap.step_matrix import StepMatrixFinder
-
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     speed_factor = 10
     step_ratio = 7
@@ -58,8 +59,9 @@ def main():
 
         return (np.abs(eigvals) <= 1 + tol).all()
 
-    from leap.stability import find_truth_bdry
     from functools import partial
+
+    from leap.stability import find_truth_bdry
 
     prec = 1e-5
     print("stable imaginary timestep:",

--- a/examples/stability/plot-stability-regions.py
+++ b/examples/stability/plot-stability-regions.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import matplotlib
+
+
 matplotlib.use("Agg")
 
 
@@ -24,8 +26,8 @@ def main(save_pdfs=True):
     pt.ylabel(r"Im $\lambda$ / RHS calls")
     pt.grid()
 
-    import leap.rk as rk
     import leap.multistep as multistep
+    import leap.rk as rk
 
     for label, method, factor in [
             #("ode23", rk.ODE23MethodBuilder("y", use_high_order=True), 1),

--- a/examples/stability/step-matrix.py
+++ b/examples/stability/step-matrix.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 import numpy as np
 import numpy.linalg as la
-from leap.rk import RK4MethodBuilder  # noqa
+
 from leap.multistep import AdamsBashforthMethodBuilder  # noqa
+from leap.rk import RK4MethodBuilder  # noqa
 
 
 def main():
-    from leap.step_matrix import StepMatrixFinder
-
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     #method = RK4MethodBuilder("y")
     method = AdamsBashforthMethodBuilder("y", order=3, static_dt=True)
@@ -42,8 +43,9 @@ def main():
 
         return (np.abs(eigvals) <= 1 + tol).all()
 
-    from leap.stability import find_truth_bdry
     from functools import partial
+
+    from leap.stability import find_truth_bdry
 
     prec = 1e-5
     print("stable imaginary timestep:",

--- a/examples/variable-coeff-wave-equation/wave-equation.py
+++ b/examples/variable-coeff-wave-equation/wave-equation.py
@@ -12,13 +12,12 @@ with piecewise constant coefficients c(x) using a multirate multistep method.
 import argparse
 import fnmatch
 import logging
+import os
+from contextlib import contextmanager
+
 import matplotlib
 import numpy as np
 import numpy.linalg as la
-import os
-
-
-from contextlib import contextmanager
 
 
 logging.basicConfig(level=logging.INFO)
@@ -261,7 +260,7 @@ def make_3_component_multirate_method(
 
     """
     from leap.multistep.multirate import (
-            MultiRateMultiStepMethodBuilder, MultiRateHistory)
+        MultiRateHistory, MultiRateMultiStepMethodBuilder)
 
     ncomponents = 3
     assert problem.ncomponents == ncomponents

--- a/leap/__init__.py
+++ b/leap/__init__.py
@@ -113,9 +113,9 @@ class TwoOrderAdaptiveMethodBuilderMixin(MethodBuilder):
         raise NotImplementedError()
 
     def finish_adaptive(self, cb, high_order_estimate, low_order_estimate):
+        from dagrt.expression import IfThenElse
         from pymbolic import var
         from pymbolic.primitives import Comparison, LogicalOr, Max, Min
-        from dagrt.expression import IfThenElse
 
         norm_start_state = var("norm_start_state")
         norm_end_state = var("norm_end_state")

--- a/leap/multistep/__init__.py
+++ b/leap/multistep/__init__.py
@@ -29,8 +29,10 @@ THE SOFTWARE.
 
 import numpy as np
 import numpy.linalg as la
-from leap import MethodBuilder
+
 from pymbolic import var
+
+from leap import MethodBuilder
 
 
 __doc__ = """
@@ -43,8 +45,8 @@ __doc__ = """
 # {{{ Adams-Bashforth integration (with and without dynamic time steps)
 
 def _linear_comb(coefficients, vectors):
-    from operator import add
     from functools import reduce
+    from operator import add
     return reduce(add,
             (coeff * v for coeff, v in zip(coefficients, vectors)))
 
@@ -277,7 +279,7 @@ class AdamsBashforthMethodBuilder(MethodBuilder):
         from pytools import UniqueNameGenerator
         name_gen = UniqueNameGenerator()
 
-        from dagrt.language import DAGCode, CodeBuilder
+        from dagrt.language import CodeBuilder, DAGCode
 
         array = var("<builtin>array")
         rhs_var = var("rhs_var")

--- a/leap/multistep/multirate/__init__.py
+++ b/leap/multistep/multirate/__init__.py
@@ -35,6 +35,7 @@ from pymbolic import var
 from leap import MethodBuilder
 from leap.multistep import _linear_comb
 
+
 __doc__ = """
 .. autoclass:: rhs_policy
 .. autoclass:: MultiRateHistory
@@ -830,9 +831,8 @@ class MultiRateMultiStepMethodBuilder(MethodBuilder):
                     dt_factor = self.dt
 
                 from leap.multistep import (
-                        AdamsMonomialIntegrationFunctionFamily,
-                        emit_adams_integration,
-                        emit_adams_extrapolation)
+                    AdamsMonomialIntegrationFunctionFamily, emit_adams_extrapolation,
+                    emit_adams_integration)
 
                 if self.is_ode_component[comp_name]:
                     contrib = dt_factor*emit_adams_integration(
@@ -1123,7 +1123,7 @@ class MultiRateMultiStepMethodBuilder(MethodBuilder):
         if explainer is None:
             explainer = SchemeExplainerBase()
 
-        from dagrt.language import DAGCode, CodeBuilder
+        from dagrt.language import CodeBuilder, DAGCode
 
         with CodeBuilder(name="initialization") as cb_init:
             self.emit_initialization(cb_init)

--- a/leap/rk/__init__.py
+++ b/leap/rk/__init__.py
@@ -27,10 +27,11 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from leap import MethodBuilder, TwoOrderAdaptiveMethodBuilderMixin
-from dagrt.language import CodeBuilder, DAGCode
 
+from dagrt.language import CodeBuilder, DAGCode
 from pymbolic import var
+
+from leap import MethodBuilder, TwoOrderAdaptiveMethodBuilderMixin
 
 
 __doc__ = """

--- a/leap/rk/imex.py
+++ b/leap/rk/imex.py
@@ -2,6 +2,7 @@
 
 
 from pymbolic import var
+
 from leap import TwoOrderAdaptiveMethodBuilderMixin
 from leap.rk import ButcherTableauMethodBuilder
 

--- a/leap/stability.py
+++ b/leap/stability.py
@@ -23,8 +23,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
 from cmath import pi
+
+import numpy as np
 
 
 __doc__ = """

--- a/leap/step_matrix.py
+++ b/leap/step_matrix.py
@@ -26,10 +26,11 @@ from typing import List, Tuple
 
 import numpy as np
 
-from dagrt.expression import EvaluationMapper
 from dagrt.exec_numpy import FailStepException
-from pymbolic.primitives import Expression
+from dagrt.expression import EvaluationMapper
 from pymbolic.interop.maxima import MaximaStringifyMapper
+from pymbolic.primitives import Expression
+
 
 __doc__ = """
 .. autoclass:: StepMatrixFinder
@@ -206,8 +207,8 @@ class StepMatrixFinder:
 
         components, initial_vals = self.run_symbolic_step(phase_name, shapes)
 
-        from pymbolic.mapper.differentiator import DifferentiationMapper
         from pymbolic.mapper.dependency import DependencyMapper
+        from pymbolic.mapper.differentiator import DifferentiationMapper
         dependencies = DependencyMapper()
 
         nv = len(components)
@@ -315,9 +316,10 @@ def fast_evaluator(matrix, sparse=False):
 
     substitutor = SubstitutionMapper(make_identifier)
 
-    from pymbolic import compile
     # functools.partial ensures the resulting object is picklable.
     from functools import partial
+
+    from pymbolic import compile
 
     if sparse:
         data = [substitutor(entry) for entry in matrix.data]

--- a/leap/transform.py
+++ b/leap/transform.py
@@ -30,7 +30,7 @@ __doc__ = """
 
 
 def _elide_yield_state(statements):
-    from dagrt.language import YieldState, Nop
+    from dagrt.language import Nop, YieldState
     return [stmt
             if not isinstance(stmt, YieldState)
             else Nop(id=stmt.id, depends_on=stmt.depends_on)
@@ -40,7 +40,7 @@ def _elide_yield_state(statements):
 def _update_t_by_dt_factor(factor, statements):
     from dagrt.language import Assign, Nop
     from pymbolic import var
-    from pymbolic.mapper.substitutor import make_subst_func, SubstitutionMapper
+    from pymbolic.mapper.substitutor import SubstitutionMapper, make_subst_func
 
     mapper = SubstitutionMapper(
         make_subst_func({"<dt>": factor * var("<dt>")}))
@@ -69,7 +69,7 @@ def strang_splitting(dag1, dag2, stepping_phase):
     :returns: a :class:`dagrt.language.DAGCode`
     """
 
-    from pymbolic.mapper.substitutor import make_subst_func, SubstitutionMapper
+    from pymbolic.mapper.substitutor import SubstitutionMapper, make_subst_func
 
     # {{{ disambiguate
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,12 @@ docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
+# enable-flake8-isort
+
+[isort]
+known_firstparty=pytools,pymbolic,dagrt
+known_local_folder=leap
+line_length = 85
+lines_after_imports = 2
+combine_as_imports = True
+multi_line_output = 4

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,9 +27,7 @@ import pytest
 def python_method_impl(request):
     kind = request.param
 
-    from utils import (
-            python_method_impl_interpreter,
-            python_method_impl_codegen)
+    from utils import python_method_impl_codegen, python_method_impl_interpreter
     if kind == "interpreter":
         return python_method_impl_interpreter
     elif kind == "codegen":

--- a/test/multirate_test_systems.py
+++ b/test/multirate_test_systems.py
@@ -25,7 +25,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from numpy import sqrt, log, sin, cos, exp
+from numpy import cos, exp, log, sin, sqrt
 
 
 class LinearODESystemsBase():

--- a/test/test_ab.py
+++ b/test/test_ab.py
@@ -27,12 +27,12 @@ THE SOFTWARE.
 # pylint: disable=not-callable
 
 import sys
-import pytest
-from leap.multistep import AdamsBashforthMethodBuilder
 
+import pytest
 from utils import (  # noqa
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg)
+    python_method_impl_codegen as pmi_cg, python_method_impl_interpreter as pmi_int)
+
+from leap.multistep import AdamsBashforthMethodBuilder
 
 
 @pytest.mark.parametrize(("method", "expected_order"), [

--- a/test/test_codegen_fortran.py
+++ b/test/test_codegen_fortran.py
@@ -26,23 +26,22 @@ THE SOFTWARE.
 # pylint: disable=not-callable
 
 import sys
+
 import pytest
 
 import dagrt.codegen.fortran as f
-from leap.rk import (
-        ODE23MethodBuilder, ODE45MethodBuilder, RK4MethodBuilder,
-        LSRK4MethodBuilder)
+from dagrt.utils import run_fortran
 
 from leap.multistep.multirate import TwoRateAdamsBashforthMethodBuilder
-
-from dagrt.utils import run_fortran
+from leap.rk import (
+    LSRK4MethodBuilder, ODE23MethodBuilder, ODE45MethodBuilder, RK4MethodBuilder)
 
 
 #skip = pytest.mark.skipif(True, reason="not fully implemented")
 
 
 def read_file(rel_path):
-    from os.path import join, abspath, dirname
+    from os.path import abspath, dirname, join
     path = join(abspath(dirname(__file__)), rel_path)
     with open(path) as inf:
         return inf.read()
@@ -66,8 +65,7 @@ def test_rk_codegen(min_order, stepper, print_code=False):
     component_id = "y"
     rhs_function = "<func>y"
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, component_id,
                             identifier=rhs_function)
     freg = freg.register_codegen(rhs_function, "fortran",
@@ -119,8 +117,7 @@ def test_rk_codegen_fancy():
             state_filter_name=state_filter_name)
 
     from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs,
-            register_function, UserType)
+        UserType, base_function_registry, register_function, register_ode_rhs)
     freg = register_ode_rhs(base_function_registry, component_id,
                             identifier=rhs_function)
     freg = freg.register_codegen(rhs_function, "fortran",
@@ -248,8 +245,7 @@ def test_multirate_codegen(min_order, method_name):
     code = stepper.generate()
 
     from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs,
-            UserType, register_function)
+        UserType, base_function_registry, register_function, register_ode_rhs)
 
     freg = base_function_registry
     for func_name in [
@@ -352,8 +348,7 @@ def test_adaptive_rk_codegen():
 
     stepper = ODE45MethodBuilder(component_id, use_high_order=False, rtol=1e-6)
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, component_id,
                             identifier=rhs_function)
     freg = freg.register_codegen(rhs_function, "fortran",
@@ -390,8 +385,7 @@ def test_adaptive_rk_codegen_error():
 
     stepper = ODE45MethodBuilder(component_id, use_high_order=False, atol=1e-6)
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, component_id,
                             identifier=rhs_function)
     freg = freg.register_codegen(rhs_function, "fortran",
@@ -427,8 +421,7 @@ def test_singlerate_squarewave(min_order, hist_length):
 
     stepper = AdamsBashforthMethodBuilder("y", min_order, hist_length=hist_length)
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
     freg = register_ode_rhs(base_function_registry, component_id,
                             identifier=rhs_function)
     freg = freg.register_codegen(rhs_function, "fortran",
@@ -487,8 +480,7 @@ def test_multirate_squarewave(min_order, hist_length, method_name):
 
     code = stepper.generate()
 
-    from dagrt.function_registry import (
-            base_function_registry, register_ode_rhs)
+    from dagrt.function_registry import base_function_registry, register_ode_rhs
 
     freg = base_function_registry
     for func_name in [

--- a/test/test_imex.py
+++ b/test/test_imex.py
@@ -26,16 +26,15 @@ THE SOFTWARE.
 # pylint: disable=not-callable
 
 
-import numpy as np
-import pytest
 import sys
 
-from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
+import numpy as np
+import pytest
 from stiff_test_systems import KapsProblem
-
 from utils import (  # noqa
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg)
+    python_method_impl_codegen as pmi_cg, python_method_impl_interpreter as pmi_int)
+
+from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
 
 
 def solver(f, t, sub_y, coeff, guess):

--- a/test/test_misc.py
+++ b/test/test_misc.py
@@ -22,11 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import logging
 import sys
 
 import numpy as np
-
-import logging
 
 
 logger = logging.getLogger(__name__)

--- a/test/test_multirate.py
+++ b/test/test_multirate.py
@@ -29,18 +29,14 @@ THE SOFTWARE.
 import numpy as np
 import numpy.linalg as la
 import pytest
-from pytools import memoize_method
-from leap.multistep.multirate import (
-        rhs_policy,
-        MultiRateHistory as MRHistory,
-        MultiRateMultiStepMethodBuilder,
-        TwoRateAdamsBashforthMethodBuilder,
-        TextualSchemeExplainer)
-
-
 from utils import (  # noqa
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg)
+    python_method_impl_codegen as pmi_cg, python_method_impl_interpreter as pmi_int)
+
+from pytools import memoize_method
+
+from leap.multistep.multirate import (
+    MultiRateHistory as MRHistory, MultiRateMultiStepMethodBuilder,
+    TextualSchemeExplainer, TwoRateAdamsBashforthMethodBuilder, rhs_policy)
 
 
 class MultirateTimestepperAccuracyChecker:
@@ -212,10 +208,11 @@ def test_multirate_accuracy(method_name, order, hist_length,
 
 
 def test_single_rate_identical(order=3, hist_length=3):
-    from leap.multistep import AdamsBashforthMethodBuilder
+    from multirate_test_systems import Full
+
     from dagrt.exec_numpy import NumpyInterpreter
 
-    from multirate_test_systems import Full
+    from leap.multistep import AdamsBashforthMethodBuilder
     ode = Full()
 
     t_start = 0

--- a/test/test_rk.py
+++ b/test/test_rk.py
@@ -25,25 +25,20 @@ THE SOFTWARE.
 # avoid spurious: pytest.mark.parametrize is not callable
 # pylint: disable=not-callable
 
+import logging
 import sys
+
+import numpy as np
 import pytest
+from utils import (  # noqa
+    python_method_impl_codegen as pmi_cg, python_method_impl_interpreter as pmi_int)
 
 from leap.rk import (
-        ODE23MethodBuilder, ODE45MethodBuilder,
-        ForwardEulerMethodBuilder,
-        MidpointMethodBuilder, HeunsMethodBuilder,
-        RK3MethodBuilder, RK4MethodBuilder, RK5MethodBuilder,
-        LSRK4MethodBuilder,
-        SSPRK22MethodBuilder, SSPRK33MethodBuilder,
-        )
+    ForwardEulerMethodBuilder, HeunsMethodBuilder, LSRK4MethodBuilder,
+    MidpointMethodBuilder, ODE23MethodBuilder, ODE45MethodBuilder, RK3MethodBuilder,
+    RK4MethodBuilder, RK5MethodBuilder, SSPRK22MethodBuilder, SSPRK33MethodBuilder)
 from leap.rk.imex import KennedyCarpenterIMEXARK4MethodBuilder
-import numpy as np
 
-import logging
-
-from utils import (  # noqa
-        python_method_impl_interpreter as pmi_int,
-        python_method_impl_codegen as pmi_cg)
 
 logger = logging.getLogger(__name__)
 

--- a/test/test_step_matrix.py
+++ b/test/test_step_matrix.py
@@ -25,14 +25,14 @@ THE SOFTWARE.
 # avoid spurious: pytest.mark.parametrize is not callable
 # pylint: disable=not-callable
 
+import logging
 import sys
+
+import numpy as np
+import numpy.linalg as la
 import pytest
 
 from leap.rk import ODE23MethodBuilder, ODE45MethodBuilder
-import numpy as np
-import numpy.linalg as la
-
-import logging
 
 
 logger = logging.getLogger(__name__)
@@ -54,9 +54,9 @@ def test_step_matrix(method, show_matrix=True, show_dag=False):
         from dagrt.language import show_dependency_graph
         show_dependency_graph(code)
     from dagrt.exec_numpy import NumpyInterpreter
-    from leap.step_matrix import StepMatrixFinder
-
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     # {{{ build matrix
 
@@ -127,8 +127,9 @@ def euler(component_id, show_dag):
 
 
 def test_step_matrix_vector_state(show_matrix=True, show_dag=False):
-    from leap.step_matrix import StepMatrixFinder
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder
 
     component_id = "y"
     code = euler(component_id, show_dag)
@@ -178,8 +179,9 @@ def test_step_matrix_fast_eval():
 
 
 def test_step_matrix_sparse():
-    from leap.step_matrix import StepMatrixFinder, fast_evaluator
     from pymbolic import var
+
+    from leap.step_matrix import StepMatrixFinder, fast_evaluator
 
     component_id = "y"
     code = euler(component_id, show_dag=False)


### PR DESCRIPTION
This replaces `pytools.Record` with dataclasses in leap too. I wasn't too sure about the types, so those should be checked more carefully: `MultiRateHistory` and `SparseStepMatrix`.

There's also a customary `flake8-isort` commit in there :grin: 